### PR TITLE
running zelcash as service

### DIFF
--- a/helpers/restartZelCash.sh
+++ b/helpers/restartZelCash.sh
@@ -16,4 +16,4 @@ sudo systemctl stop zelcash >/dev/null 2>&1 && sleep 3
 sudo killall "$COIN_DAEMON" >/dev/null 2>&1
 sudo killall -s SIGKILL zelbenchd >/dev/null 2>&1
 sleep 2
-"$COIN_DAEMON"
+sudo systemctl start zelcash


### PR DESCRIPTION
after first reboot service will be activate no reason to not using it from runing zelcash in this way is possibe better track errors and prevent from crash and chceck when update is tigerred