### PR TITLE
v0.66.0

### DIFF
--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -55,8 +55,8 @@ module.exports = {
       ram: 1 * 5, // per 100mb,
       hdd: 0.5 * 5, // per 1gb,
     },
-    address: 't1...', // apps registration address
-    epochstart: 1000000, // zelapps epoch blockheight start
+    address: 't1TH5KaFi9CbMQasGB294yYgoWAuzXNfRMR', // apps registration address
+    epochstart: 640000, // zelapps epoch blockheight start
     portMin: 30001, // originally should have been from 30000 but we got temporary folding there
     portMax: 39999,
     maxImageSize: 300000000, // 300mb

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -58,8 +58,8 @@ module.exports = {
       ram: 1 * 5, // per 100mb,
       hdd: 0.5 * 5, // per 1gb,
     },
-    address: 't1TH5KaFi9CbMQasGB294yYgoWAuzXNfRMR', // apps registration address
-    epochstart: 640000, // zelapps epoch blockheight start
+    address: 't1...', // apps registration address
+    epochstart: 690000, // zelapps epoch blockheight start
     portMin: 30001, // originally should have been from 30000 but we got temporary folding there
     portMax: 39999,
     maxImageSize: 300000000, // 300mb

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -47,6 +47,9 @@ module.exports = {
     porttestnet: 26225,
     rpcporttestnet: 26224,
   },
+  zelcash: {
+    chainValidHeight: 640000,
+  },
   zelTeamZelId: '132hG26CFTNhLM3MRsLEJhp9DpBrK6vg5N',
   zelapps: {
     // in zel per month

--- a/ZelBack/server.js
+++ b/ZelBack/server.js
@@ -6,7 +6,7 @@ const config = require('config');
 // const path = require('path');
 const app = require('./src/lib/server.js');
 const log = require('./src/lib/log');
-const communication = require('./src/services/zelfluxCommunication');
+const serviceManager = require('./src/services/serviceManager');
 
 // const key = fs.readFileSync(path.join(__dirname, '../certs/selfsigned.key'), 'utf8');
 // const cert = fs.readFileSync(path.join(__dirname, '../certs/selfsigned.crt'), 'utf8');
@@ -19,5 +19,5 @@ const communication = require('./src/services/zelfluxCommunication');
 
 app.listen(config.server.apiport, () => {
   log.info(`ZelBack listening on port ${config.server.apiport}!`);
-  communication.startFluxFunctions();
+  serviceManager.startFluxFunctions();
 });

--- a/ZelBack/src/lib/log.js
+++ b/ZelBack/src/lib/log.js
@@ -8,7 +8,8 @@ function getFilesizeInBytes(filename) {
     const stats = fs.statSync(filename);
     const fileSizeInBytes = stats.size;
     return fileSizeInBytes;
-  } catch {
+  } catch (e) {
+    console.log(e);
     return 0;
   }
 }

--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -251,6 +251,9 @@ module.exports = (app, expressWs) => {
   app.get('/zelapps/globalspecifications', (req, res) => {
     zelappsService.getGlobalZelAppsSpecifications(req, res);
   });
+  app.get('/zelapps/hashes', (req, res) => {
+    zelappsService.getZelAppHashes(req, res);
+  });
 
   // app.get('/explorer/allutxos', (req, res) => {
   //   explorerService.getAllUtxos(req, res);

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -946,7 +946,7 @@ async function reindexExplorer(req, res) {
 async function rescanExplorer(req, res) {
   try {
     const authorized = await serviceHelper.verifyPrivilege('zelteam', req);
-    if (authorized === true) {
+    if (true) {
       // since what blockheight
       let { blockheight } = req.params; // we accept both help/command and help?command=getinfo
       blockheight = blockheight || req.query.blockheight;

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -536,17 +536,17 @@ async function initiateBlockProcessor(restoreDatabase, deepRestore, reindexOrRes
         });
         log.info(resultE, resultF);
       }
-      await databaseGlobal.collection(config.database.zelappsglobal.collections.zelappsMessages).createIndex({ hash: 1 }, { name: 'query for getting zelapp message based on hash' });
+      await databaseGlobal.collection(config.database.zelappsglobal.collections.zelappsMessages).createIndex({ hash: 1 }, { name: 'query for getting zelapp message based on hash' }); // , unique: true
       await databaseGlobal.collection(config.database.zelappsglobal.collections.zelappsMessages).createIndex({ txid: 1 }, { name: 'query for getting zelapp message based on txid' });
       await databaseGlobal.collection(config.database.zelappsglobal.collections.zelappsMessages).createIndex({ height: 1 }, { name: 'query for getting zelapp message based on height' });
-      await databaseGlobal.collection(config.database.zelappsglobal.collections.zelappsMessages).createIndex({ 'zelAppSpecifications.name': 1 }, { name: 'query for getting zelapp message based on zelapp specs name' });
+      await databaseGlobal.collection(config.database.zelappsglobal.collections.zelappsMessages).createIndex({ 'zelAppSpecifications.name': 1 }, { name: 'query for getting zelapp message based on zelapp specs name' }); // , unique: true
       await databaseGlobal.collection(config.database.zelappsglobal.collections.zelappsMessages).createIndex({ 'zelAppSpecifications.owner': 1 }, { name: 'query for getting zelapp message based on zelapp specs owner' });
       await databaseGlobal.collection(config.database.zelappsglobal.collections.zelappsMessages).createIndex({ 'zelAppSpecifications.repotag': 1 }, { name: 'query for getting zelapp message based on image' });
-      await databaseGlobal.collection(config.database.zelappsglobal.collections.zelappsInformation).createIndex({ name: 1 }, { name: 'query for getting zelapp based on zelapp specs name' });
+      await databaseGlobal.collection(config.database.zelappsglobal.collections.zelappsInformation).createIndex({ name: 1 }, { name: 'query for getting zelapp based on zelapp specs name' }); // , unique: true
       await databaseGlobal.collection(config.database.zelappsglobal.collections.zelappsInformation).createIndex({ owner: 1 }, { name: 'query for getting zelapp based on zelapp specs owner' });
       await databaseGlobal.collection(config.database.zelappsglobal.collections.zelappsInformation).createIndex({ repotag: 1 }, { name: 'query for getting zelapp based on image' });
       await databaseGlobal.collection(config.database.zelappsglobal.collections.zelappsInformation).createIndex({ height: 1 }, { name: 'query for getting zelapp based on last height update' }); // we need to know the height of app adjustment
-      await databaseGlobal.collection(config.database.zelappsglobal.collections.zelappsInformation).createIndex({ hash: 1 }, { name: 'query for getting zelapp based on last hash' }); // we need to know the hash of the last message update which is the true identifier
+      await databaseGlobal.collection(config.database.zelappsglobal.collections.zelappsInformation).createIndex({ hash: 1 }, { name: 'query for getting zelapp based on last hash' }); // , unique: true // we need to know the hash of the last message update which is the true identifier
       // what if 2 app adjustment come in the same block?
       // log.info(resultE, resultF);
       log.info('Preparation done');
@@ -946,7 +946,7 @@ async function reindexExplorer(req, res) {
 async function rescanExplorer(req, res) {
   try {
     const authorized = await serviceHelper.verifyPrivilege('zelteam', req);
-    if (authorized === true) {
+    if (true) {
       // since what blockheight
       let { blockheight } = req.params; // we accept both help/command and help?command=getinfo
       blockheight = blockheight || req.query.blockheight;

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -435,7 +435,7 @@ async function restoreDatabaseToBlockheightState(height, rescanGlobalApps = fals
     throw error;
   });
   if (rescanGlobalApps === true) {
-    const databaseGlobal = database.db(config.database.zelappsglobal.database);
+    const databaseGlobal = dbopen.db(config.database.zelappsglobal.database);
     log.info('Rescanning Apps!');
     await serviceHelper.removeDocumentsFromCollection(databaseGlobal, config.database.zelappsglobal.collections.zelappsMessages, query).catch((error) => {
       log.error(error);

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -325,9 +325,9 @@ async function processBlock(blockHeight) {
           await serviceHelper.updateOneInDatabase(database, addressTransactionIndexCollection, query, update, options);
         }));
         // MAY contain ZelApp transaction. Store it.
-        if (isZelAppMessageValue > 0 && message.length === 64 && blockDataVerbose.height >= config.zelapps.epochstart) {
+        if (isZelAppMessageValue >= 10 && message.length === 64 && blockDataVerbose.height >= config.zelapps.epochstart) { // min of 10 zel had to be paid for us bothering checking
           const zelappTxRecord = {
-            txid: tx.txid, height: blockDataVerbose.height, hash: message, value: isZelAppMessageValue,
+            txid: tx.txid, height: blockDataVerbose.height, hash: message, value: isZelAppMessageValue, message: false, // message is boolean saying if we already have it stored as permanent message
           };
           await serviceHelper.insertOneToDatabase(database, zelappsHashesCollection, zelappTxRecord);
           zelappsService.checkAndRequestZelApp(message, tx.txid, blockDataVerbose.height, isZelAppMessageValue);

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -832,7 +832,7 @@ async function getScannedHeight(req, res) {
   const projection = {
     projection: {
       _id: 0,
-      generalScannedHeight: 1, //
+      generalScannedHeight: 1,
     },
   };
   const result = await serviceHelper.findOneInDatabase(database, scannedHeightCollection, query, projection).catch((error) => {
@@ -964,13 +964,13 @@ async function rescanExplorer(req, res) {
           generalScannedHeight: 1,
         },
       };
-      const currentHeight = await serviceHelper.findOneInDatabase(database, scannedHeightCollection, query, projection);
-      if (!currentHeight) {
-        throw new Error('No scanned height found');
-      }
-      if (currentHeight.generalScannedHeight <= blockheight) {
-        throw new Error('Block height shall be lower than currently scanned');
-      }
+      // const currentHeight = await serviceHelper.findOneInDatabase(database, scannedHeightCollection, query, projection);
+      // if (!currentHeight) {
+      //   throw new Error('No scanned height found');
+      // }
+      // if (currentHeight.generalScannedHeight <= blockheight) {
+      //   throw new Error('Block height shall be lower than currently scanned');
+      // }
       let { rescanapps } = req.params;
       rescanapps = rescanapps || req.query.rescanapps || false;
       rescanapps = serviceHelper.ensureBoolean(rescanapps);

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -325,7 +325,7 @@ async function processBlock(blockHeight) {
           await serviceHelper.updateOneInDatabase(database, addressTransactionIndexCollection, query, update, options);
         }));
         // MAY contain ZelApp transaction. Store it.
-        if (isZelAppMessageValue > 0 && message.length === 64) {
+        if (isZelAppMessageValue > 0 && message.length === 64 && blockDataVerbose.height >= config.zelapps.epochstart) {
           const zelappTxRecord = {
             txid: tx.txid, height: blockDataVerbose.height, hash: message, value: isZelAppMessageValue,
           };

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -946,7 +946,7 @@ async function reindexExplorer(req, res) {
 async function rescanExplorer(req, res) {
   try {
     const authorized = await serviceHelper.verifyPrivilege('zelteam', req);
-    if (true) {
+    if (authorized === true) {
       // since what blockheight
       let { blockheight } = req.params; // we accept both help/command and help?command=getinfo
       blockheight = blockheight || req.query.blockheight;

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -519,6 +519,7 @@ async function initiateBlockProcessor(restoreDatabase, deepRestore, reindexOrRes
       await database.collection(zelappsHashesCollection).createIndex({ txid: 1 }, { name: 'query for getting txid' });
       await database.collection(zelappsHashesCollection).createIndex({ height: 1 }, { name: 'query for getting height' });
       await database.collection(zelappsHashesCollection).createIndex({ hash: 1 }, { name: 'query for getting app hash' });
+      await database.collection(zelappsHashesCollection).createIndex({ message: 1 }, { name: 'query for getting app hashes depending if we have message' });
 
       const databaseGlobal = db.db(config.database.zelappsglobal.database);
       log.info('Preparing apps collections');

--- a/ZelBack/src/services/explorerService.js
+++ b/ZelBack/src/services/explorerService.js
@@ -575,7 +575,7 @@ async function initiateBlockProcessor(restoreDatabase, deepRestore, reindexOrRes
           log.error('Error restoring database!');
           throw e;
         }
-      } else if (scannedBlockHeight > 600000) {
+      } else if (scannedBlockHeight > config.zelcash.chainValidHeight) {
         const zelcashGetChainTips = await zelcashService.getChainTips();
         if (zelcashGetChainTips.status !== 'success') {
           throw new Error(zelcashGetChainTips.data);
@@ -946,7 +946,7 @@ async function reindexExplorer(req, res) {
 async function rescanExplorer(req, res) {
   try {
     const authorized = await serviceHelper.verifyPrivilege('zelteam', req);
-    if (true) {
+    if (authorized === true) {
       // since what blockheight
       let { blockheight } = req.params; // we accept both help/command and help?command=getinfo
       blockheight = blockheight || req.query.blockheight;

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -43,10 +43,9 @@ async function startFluxFunctions() {
     }, 60000);
     log.info('Flux checks operational');
     explorerService.initiateBlockProcessor(true, true);
-    zelappsService.continuousZelAppHashesCheck();
     setInterval(() => { // every one hour
       zelappsService.continuousZelAppHashesCheck();
-    }, 60 * 60 * 1000);
+    }, 5 * 60 * 1000);
     log.info('Flux Block Processing Service started');
   } catch (e) {
     log.error(e);

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -30,7 +30,7 @@ async function startFluxFunctions() {
     log.info('Preparing temporary database...');
     // no need to drop temporary messages
     const databaseTemp = db.db(config.database.zelappsglobal.database);
-    await databaseTemp.collection(config.database.zelappsglobal.collections.zelappsTemporaryMessages).createIndex({ createdAt: 1 }, { expireAfterSeconds: 3600 });
+    await databaseTemp.collection(config.database.zelappsglobal.collections.zelappsTemporaryMessages).createIndex({ receivedAt: 1 }, { expireAfterSeconds: 3600 });
     log.info('Temporary database prepared');
     zelfluxCommunication.adjustFirewall();
     zelfluxCommunication.fluxDisovery();

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -33,7 +33,7 @@ async function startFluxFunctions() {
     await databaseTemp.collection(config.database.zelappsglobal.collections.zelappsTemporaryMessages).createIndex({ createdAt: 1 }, { expireAfterSeconds: 3600 });
     log.info('Temporary database prepared');
     zelfluxCommunication.adjustFirewall();
-    // zelfluxCommunication.fluxDisovery();
+    zelfluxCommunication.fluxDisovery();
     log.info('Flux Discovery started');
     zelfluxCommunication.keepConnectionsAlive();
     zelfluxCommunication.keepIncomingConnectionsAlive();
@@ -43,9 +43,9 @@ async function startFluxFunctions() {
     }, 60000);
     log.info('Flux checks operational');
     explorerService.initiateBlockProcessor(true, true);
-    setInterval(() => { // every one hour
+    setInterval(() => { // every 8 mins (4 blocks)
       zelappsService.continuousZelAppHashesCheck();
-    }, 0.5 * 60 * 1000);
+    }, 8 * 60 * 1000);
     log.info('Flux Block Processing Service started');
   } catch (e) {
     log.error(e);

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -45,7 +45,7 @@ async function startFluxFunctions() {
     explorerService.initiateBlockProcessor(true, true);
     setInterval(() => { // every one hour
       zelappsService.continuousZelAppHashesCheck();
-    }, 5 * 60 * 1000);
+    }, 0.5 * 60 * 1000);
     log.info('Flux Block Processing Service started');
   } catch (e) {
     log.error(e);

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -33,7 +33,7 @@ async function startFluxFunctions() {
     await databaseTemp.collection(config.database.zelappsglobal.collections.zelappsTemporaryMessages).createIndex({ createdAt: 1 }, { expireAfterSeconds: 3600 });
     log.info('Temporary database prepared');
     zelfluxCommunication.adjustFirewall();
-    zelfluxCommunication.fluxDisovery();
+    // zelfluxCommunication.fluxDisovery();
     log.info('Flux Discovery started');
     zelfluxCommunication.keepConnectionsAlive();
     zelfluxCommunication.keepIncomingConnectionsAlive();

--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -1,0 +1,61 @@
+const config = require('config');
+const log = require('../lib/log');
+
+const serviceHelper = require('./serviceHelper');
+const explorerService = require('./explorerService');
+const zelfluxCommunication = require('./zelfluxCommunication');
+const zelappsService = require('./zelappsService');
+
+async function startFluxFunctions() {
+  try {
+    log.info('Initiating MongoDB connection');
+    await serviceHelper.initiateDB(); // either true or throws error
+    log.info('DB connected');
+    log.info('Preparing local database...');
+    const db = serviceHelper.databaseConnection();
+    const database = db.db(config.database.local.database);
+    await serviceHelper.dropCollection(database, config.database.local.collections.activeLoginPhrases).catch((error) => {
+      if (error.message !== 'ns not found') {
+        log.error(error);
+      }
+    });
+    await serviceHelper.dropCollection(database, config.database.local.collections.activeSignatures).catch((error) => {
+      if (error.message !== 'ns not found') {
+        log.error(error);
+      }
+    });
+    await database.collection(config.database.local.collections.activeLoginPhrases).createIndex({ createdAt: 1 }, { expireAfterSeconds: 900 });
+    await database.collection(config.database.local.collections.activeSignatures).createIndex({ createdAt: 1 }, { expireAfterSeconds: 900 });
+    log.info('Local database prepared');
+    log.info('Preparing temporary database...');
+    // no need to drop temporary messages
+    const databaseTemp = db.db(config.database.zelappsglobal.database);
+    await databaseTemp.collection(config.database.zelappsglobal.collections.zelappsTemporaryMessages).createIndex({ createdAt: 1 }, { expireAfterSeconds: 3600 });
+    log.info('Temporary database prepared');
+    zelfluxCommunication.adjustFirewall();
+    zelfluxCommunication.fluxDisovery();
+    log.info('Flux Discovery started');
+    zelfluxCommunication.keepConnectionsAlive();
+    zelfluxCommunication.keepIncomingConnectionsAlive();
+    zelfluxCommunication.checkDeterministicNodesCollisions();
+    setInterval(() => {
+      zelfluxCommunication.checkDeterministicNodesCollisions();
+    }, 60000);
+    log.info('Flux checks operational');
+    explorerService.initiateBlockProcessor(true, true);
+    zelappsService.continuousZelAppHashesCheck();
+    setInterval(() => { // every one hour
+      zelappsService.continuousZelAppHashesCheck();
+    }, 60 * 60 * 1000);
+    log.info('Flux Block Processing Service started');
+  } catch (e) {
+    log.error(e);
+    setTimeout(() => {
+      startFluxFunctions();
+    }, 15000);
+  }
+}
+
+module.exports = {
+  startFluxFunctions,
+};

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -2852,6 +2852,34 @@ async function rescanGlobalAppsInformation(height = 0, removeLastInformation = f
   }
 }
 
+async function continuousZelAppHashesCheck() {
+  try {
+    // get zelapp hashes that do not have a message;
+    const dbopen = serviceHelper.databaseConnection();
+    const database = dbopen.db(config.database.zelcash.database);
+    const query = { message: false };
+    const projection = {
+      projection: {
+        _id: 0,
+        txid: 1,
+        hash: 1,
+        height: 1,
+        value: 1,
+        message: 1,
+      },
+    };
+    const results = await serviceHelper.findInDatabase(database, zelappsHashesCollection, query, projection);
+    // eslint-disable-next-line no-restricted-syntax
+    for (const result of results) {
+      checkAndRequestZelApp(result.hash, result.txid, result.height, result.value);
+      // eslint-disable-next-line no-await-in-loop
+      await serviceHelper.delay(1234);
+    }
+  } catch (error) {
+    log.error(error);
+  }
+}
+
 module.exports = {
   dockerListContainers,
   zelAppPull,
@@ -2898,4 +2926,5 @@ module.exports = {
   verifyZelAppMessageSignature,
   reindexGlobalAppsInformation,
   rescanGlobalAppsInformation,
+  continuousZelAppHashesCheck,
 };

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -2854,6 +2854,7 @@ async function rescanGlobalAppsInformation(height = 0, removeLastInformation = f
 
 async function continuousZelAppHashesCheck() {
   try {
+    log.info('Requesting missing ZelApp messages');
     // get zelapp hashes that do not have a message;
     const dbopen = serviceHelper.databaseConnection();
     const database = dbopen.db(config.database.zelcash.database);

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -2880,6 +2880,30 @@ async function continuousZelAppHashesCheck() {
   }
 }
 
+async function getZelAppHashes(req, res) {
+  const dbopen = serviceHelper.databaseConnection();
+  const database = dbopen.db(config.database.zelcash.database);
+  const query = {};
+  const projection = {
+    projection: {
+      _id: 0,
+      txid: 1,
+      hash: 1,
+      height: 1,
+      value: 1,
+      message: 1,
+    },
+  };
+  const results = await serviceHelper.findInDatabase(database, zelappsHashesCollection, query, projection).catch((error) => {
+    const errMessage = serviceHelper.createErrorMessage(error.message, error.name, error.code);
+    res.json(errMessage);
+    log.error(error);
+    throw error;
+  });
+  const resultsResponse = serviceHelper.createDataMessage(results);
+  res.json(resultsResponse);
+}
+
 module.exports = {
   dockerListContainers,
   zelAppPull,
@@ -2927,4 +2951,5 @@ module.exports = {
   reindexGlobalAppsInformation,
   rescanGlobalAppsInformation,
   continuousZelAppHashesCheck,
+  getZelAppHashes,
 };

--- a/ZelBack/src/services/zelfluxCommunication.js
+++ b/ZelBack/src/services/zelfluxCommunication.js
@@ -688,7 +688,7 @@ async function initiateAndHandleConnection(ip) {
       conIP = conIP.split(`:${config.server.apiport}`).join('');
       const msgObj = serviceHelper.ensureObject(evt.data);
       if (msgObj.data.type === 'zelappregister') {
-        handleZelAppRegisterMessage(msgObj.data, conIP);
+        handleZelAppRegisterMessage(msgObj, conIP);
       } else if (msgObj.data.type === 'zelapprequest') {
         respondWithAppMessage(msgObj, websocket);
       } else if (msgObj.data.type === 'HeartBeat' && msgObj.data.message === 'pong') {

--- a/ZelFront/src/components/ZelApps.vue
+++ b/ZelFront/src/components/ZelApps.vue
@@ -77,7 +77,7 @@
               sortable
             >
               <template slot-scope="scope">
-                {{ scope.row.name.substr(3, scope.row.name.length) }}
+                {{ getZelAppName(scope.row.name) }}
               </template>
             </el-table-column>
             <el-table-column
@@ -164,7 +164,86 @@
               sortable
             >
               <template slot-scope="scope">
-                {{ scope.row.name.substr(3, scope.row.name.length) }}
+                {{ getZelAppName(scope.row.name) }}
+              </template>
+            </el-table-column>
+            <el-table-column
+              label="Image"
+              prop="repotag"
+              sortable
+            >
+            </el-table-column>
+            <el-table-column
+              label="Owner"
+              prop="owner"
+              sortable
+            >
+            </el-table-column>
+            <el-table-column
+              label="Port"
+              prop="port"
+              sortable
+            >
+            </el-table-column>
+            <el-table-column
+              label="CPU"
+              prop="cpu"
+              sortable
+            >
+              <template slot-scope="scope">
+                {{ resolveCpu(scope.row) }}
+              </template>
+            </el-table-column>
+            <el-table-column
+              label="RAM"
+              prop="ram"
+              sortable
+            >
+              <template slot-scope="scope">
+                {{ resolveRam(scope.row) }}
+              </template>
+            </el-table-column>
+            <el-table-column
+              label="HDD"
+              prop="hdd"
+              sortable
+            >
+              <template slot-scope="scope">
+                {{ resolveHdd(scope.row) }}
+              </template>
+            </el-table-column>
+          </el-table>
+        </el-tab-pane>
+      </el-tabs>
+      <br>
+      <div class='actionCenter'>
+        <el-input
+          v-if="output"
+          type="textarea"
+          autosize
+          v-model="stringOutput"
+        >
+        </el-input>
+      </div>
+    </div>
+    <div v-if="zelAppsSection === 'globalzelapps'">
+      <el-tabs v-model="activeNameGlobal">
+        <el-tab-pane
+          label="Available"
+          name="available"
+        >
+          <el-table
+            :data="globalZelAppSpecs.data"
+            empty-text="No global ZelApp"
+            style="width: 100%"
+          >
+            <el-table-column
+              label="Name"
+              prop="name"
+              sortable
+            >
+              <template slot-scope="scope">
+                {{ getZelAppName(scope.row.name) }}
               </template>
             </el-table-column>
             <el-table-column
@@ -554,6 +633,7 @@ export default {
   data() {
     return {
       activeName: 'running',
+      activeNameGlobal: 'available',
       getRunningZelAppsResponse: {
         status: '',
         data: '',
@@ -567,6 +647,10 @@ export default {
         data: '',
       },
       availableZelApps: {
+        status: '',
+        data: '',
+      },
+      globalZelAppSpecs: {
         status: '',
         data: '',
       },
@@ -664,8 +748,8 @@ export default {
           ram: 1 * 5, // per 100mb,
           hdd: 0.5 * 5, // per 1gb,
         },
-        address: 't1TH5KaFi9CbMQasGB294yYgoWAuzXNfRMR', // apps registration address
-        epochstart: 640000, // zelapps epoch blockheight start
+        address: 't1...', // apps registration address
+        epochstart: 690000, // zelapps epoch blockheight start
         portMin: 30001, // originally should have been from 30000 but we got temporary folding there
         portMax: 39999,
       },
@@ -714,10 +798,9 @@ export default {
       switch (val) {
         case 'localzelapps':
           this.zelappsGetListRunningZelApps();
-          // vue.$message.info('ZelApps coming soon!');
           break;
         case 'globalzelapps':
-          vue.$message.info('ZelApps coming soon!');
+          this.zelappsGetListGlobalZelApps();
           break;
         case 'registerzelapp':
           this.registrationInformation();
@@ -776,10 +859,9 @@ export default {
     switch (this.zelAppsSection) {
       case 'localzelapps':
         this.zelappsGetListRunningZelApps();
-        // vue.$message.info('ZelApps coming soon!');
         break;
       case 'globalzelapps':
-        vue.$message.info('ZelApps coming soon!');
+        this.zelappsGetListGlobalZelApps();
         break;
       case 'registerzelapp':
         this.registrationInformation();
@@ -790,6 +872,11 @@ export default {
     }
   },
   methods: {
+    async zelappsGetListGlobalZelApps() {
+      const response = await ZelAppsService.globalZelAppSpecifications();
+      this.globalZelAppSpecs.status = response.data.status;
+      this.globalZelAppSpecs.data = response.data.data;
+    },
     async zelappsGetAvailableZelApps() {
       const response = await ZelAppsService.availableZelApps();
       this.availableZelApps.status = response.data.status;
@@ -1282,6 +1369,13 @@ export default {
     },
     onOpen(evt) {
       console.log(evt);
+    },
+    getZelAppName(zelappName) {
+      // this id is used for volumes, docker names so we know it reall belongs to zelflux
+      if (zelappName.startsWith('zel')) {
+        return zelappName.substr(3, zelappName.length);
+      }
+      return zelappName;
     },
   },
 };

--- a/ZelFront/src/components/ZelApps.vue
+++ b/ZelFront/src/components/ZelApps.vue
@@ -573,7 +573,7 @@ export default {
       tier: '',
       output: '',
       fluxCommunication: false,
-      zelAppRegistrationSpecification: {
+      zelAppRegistrationSpecificationB: {
         version: 1,
         name: '',
         description: '',
@@ -598,9 +598,9 @@ export default {
         rambamf: null,
         hddbamf: null,
       },
-      zelAppRegistrationSpecificationB: {
+      zelAppRegistrationSpecification: {
         version: 1,
-        name: 'FoldingAtHome',
+        name: 'tralalafolding',
         description: 'Folding @ Home is cool :)',
         repotag: 'yurinnick/folding-at-home:latest',
         owner: '1CbErtneaX2QVyUfwU7JGB7VzvPgrgc3uC',
@@ -612,7 +612,7 @@ export default {
         cpu: 0.5,
         ram: 500,
         hdd: 5,
-        tiered: true,
+        tiered: false,
         cpubasic: 0.5,
         rambasic: 500,
         hddbasic: 5,

--- a/ZelFront/src/components/ZelApps.vue
+++ b/ZelFront/src/components/ZelApps.vue
@@ -522,12 +522,12 @@
           <br><br>
           <div v-if="registrationHash">
             {{ registrationHash }}
-            <!--To finish registration, Please do a transaction of {{ appPricePerMonth }} to address
+            To finish registration, Please do a transaction of {{ appPricePerMonth }} to address
             {{ zelapps.address }}
             with following message:
             {{ registrationHash }}
             <br><br>
-            Transaction must be mined by {{ validTill }} -->
+            Transaction must be mined by {{ validTill }}
           </div>
         </div>
       </div>
@@ -664,8 +664,8 @@ export default {
           ram: 1 * 5, // per 100mb,
           hdd: 0.5 * 5, // per 1gb,
         },
-        address: 't1...', // apps registration address
-        epochstart: 1000000, // zelapps epoch blockheight start
+        address: 't1TH5KaFi9CbMQasGB294yYgoWAuzXNfRMR', // apps registration address
+        epochstart: 640000, // zelapps epoch blockheight start
         portMin: 30001, // originally should have been from 30000 but we got temporary folding there
         portMax: 39999,
       },

--- a/ZelFront/src/components/ZelCash.vue
+++ b/ZelFront/src/components/ZelCash.vue
@@ -137,7 +137,9 @@ export default {
     },
     async restartZelCashDaemon() {
       const zelidauth = localStorage.getItem('zelidauth');
+      vue.$message.success('Restarting ZelCash...');
       const response = await ZelCashService.restart(zelidauth);
+      console.log(response);
       vue.$message({
         type: response.data.status,
         message: response.data.data.message || response.data.data,

--- a/ZelFront/src/components/shared/Header.vue
+++ b/ZelFront/src/components/shared/Header.vue
@@ -165,9 +165,7 @@
         </el-menu-item>
         <!--<el-menu-item index="10-4">Active Login Phrases</el-menu-item>-->
       </el-submenu>
-      <el-menu-item
-        index="50"
-      >
+      <el-menu-item index="50">
         Very Basic Explorer
       </el-menu-item>
       <el-menu-item
@@ -257,6 +255,9 @@ export default {
           break;
         case '3-1':
           this.$store.commit('setZelAppsSection', 'localzelapps');
+          break;
+        case '3-2':
+          this.$store.commit('setZelAppsSection', 'globalzelapps');
           break;
         case '3-3':
           this.$store.commit('setZelAppsSection', 'registerzelapp');

--- a/ZelFront/src/services/ZelAppsService.js
+++ b/ZelFront/src/services/ZelAppsService.js
@@ -92,6 +92,9 @@ export default {
   zelappsRegInformation() {
     return Api().get('/zelapps/registrationinformation');
   },
+  globalZelAppSpecifications() {
+    return Api().get('/zelapps/globalspecifications');
+  },
   justAPI() {
     return Api();
   },

--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ const path = require('path');
 const express = require('express');
 const app = require('./ZelBack/src/lib/server.js');
 const log = require('./ZelBack/src/lib/log');
-const communication = require('./ZelBack/src/services/zelfluxCommunication');
+const serviceManager = require('./ZelBack/src/services/serviceManager');
 
 // const key = fs.readFileSync(path.join(__dirname, './certs/selfsigned.key'), 'utf8');
 // const cert = fs.readFileSync(path.join(__dirname, './certs/selfsigned.crt'), 'utf8');
@@ -20,7 +20,7 @@ const communication = require('./ZelBack/src/services/zelfluxCommunication');
 
 app.listen(config.server.apiport, () => {
   log.info(`ZelBack running on port ${config.server.apiport}!`);
-  communication.startFluxFunctions();
+  serviceManager.startFluxFunctions();
 });
 
 // ZelFront configuration

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zelflux",
-  "version": "0.65.0",
+  "version": "0.65.1",
   "description": "Flux - Node Daemon. The entrace to the Flux network.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zelflux",
-  "version": "0.65.2",
+  "version": "0.65.3",
   "description": "Flux - Node Daemon. The entrace to the Flux network.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zelflux",
-  "version": "0.65.4",
+  "version": "0.66.0",
   "description": "Flux - Node Daemon. The entrace to the Flux network.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zelflux",
-  "version": "0.65.3",
+  "version": "0.65.4",
   "description": "Flux - Node Daemon. The entrace to the Flux network.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zelflux",
-  "version": "0.65.1",
+  "version": "0.65.2",
   "description": "Flux - Node Daemon. The entrace to the Flux network.",
   "repository": {
     "type": "git",

--- a/vue.config.js
+++ b/vue.config.js
@@ -4,7 +4,6 @@ const path = require('path');
 // const CompressionPlugin = require('compression-webpack-plugin');
 // const zopfli = require('@gfx/zopfli');
 
-
 const plugins = [];
 // if (process.env.NODE_ENV === 'production') {
 //   const compressionTest = /\.(js|css|json|txt|html|ico|svg)(\?.*)?$/i;


### PR DESCRIPTION
correct handleZelAppRegisterMessage
introduce serviceManager that starts flux instead of communication service
available call /zelapps/hashes
tweak conditions for scanning app hashes
add boolean message parameter to app hashes
continuous scanning of for missing zelapps messages
do not check for possible forks on safe heights
use findOne for scanned height
tweak storing with random delays
fix db rescan for apps
