### PR TITLE
v1.2.0

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 /config/userconfig.js
 /lib/
 /tests/
+/ZelApps/

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ ZelFront/test/e2e/reports/
 ZelFront/selenium-debug.log
 ZelFront/package-lock.json
 config/userconfig.js
+ZelApps
 
 # Editor directories and files
 .idea

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -41,6 +41,12 @@ module.exports = {
         zelappsLocations: 'zelappslocation', // stores location of zelapps as documents containing name, hash, ip, obtainedAt
       },
     },
+    zelshare: {
+      database: 'zelshare',
+      collections: {
+        shared: 'shared',
+      },
+    },
   },
   zelbench: {
     port: 16225,

--- a/ZelBack/config/default.js
+++ b/ZelBack/config/default.js
@@ -79,7 +79,7 @@ module.exports = {
     },
     redeploy: {
       probability: 2, // 50%
-      delay: 180,
+      delay: 30,
     },
     blocksLasting: 22000, // registered app will live for 22000 of blocks 44000 minutes ~= 1 month
     expireZelAppsPeriod: 100, // every 100 blocks we run a check that deletes apps specifications and stops/removes the application from existence if it has been lastly updated more than 22k blocks ago

--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -863,4 +863,7 @@ module.exports = (app, expressWs) => {
   app.get('/zelapps/zelshare/fileexists/:file?', (req, res) => {
     zelappsService.zelShareFileExists(req, res);
   });
+  app.get('/zelapps/zelshare/stats', (req, res) => {
+    zelappsService.zelShareStorageStats(req, res);
+  });
 };

--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -12,139 +12,139 @@ const cache = apicache.middleware;
 
 module.exports = (app, expressWs) => {
   // GET PUBLIC methods
-  app.get('/zelcash/help/:command?', cache('1 minute'), (req, res) => { // accept both help/command and ?command=getinfo. If ommited, default help will be displayed. Other calls works in similar way
+  app.get('/zelcash/help/:command?', cache('1 hour'), (req, res) => { // accept both help/command and ?command=getinfo. If ommited, default help will be displayed. Other calls works in similar way
     zelcashService.help(req, res);
   });
-  app.get('/zelcash/getinfo', cache('10 seconds'), (req, res) => {
+  app.get('/zelcash/getinfo', cache('30 seconds'), (req, res) => {
     zelcashService.getInfo(req, res);
   });
-  app.get('/zelcash/getzelnodestatus', cache('10 seconds'), (req, res) => {
+  app.get('/zelcash/getzelnodestatus', cache('30 seconds'), (req, res) => {
     zelcashService.getZelNodeStatus(req, res);
   });
-  app.get('/zelcash/listzelnodes/:filter?', cache('10 seconds'), (req, res) => {
+  app.get('/zelcash/listzelnodes/:filter?', cache('30 seconds'), (req, res) => {
     zelcashService.listZelNodes(req, res);
   });
-  app.get('/zelcash/viewdeterministiczelnodelist/:filter?', cache('10 seconds'), (req, res) => {
+  app.get('/zelcash/viewdeterministiczelnodelist/:filter?', cache('30 seconds'), (req, res) => {
     zelcashService.viewDeterministicZelNodeList(req, res);
   });
-  app.get('/zelcash/znsync/:mode?', cache('1 minute'), (req, res) => {
+  app.get('/zelcash/znsync/:mode?', cache('30 seconds'), (req, res) => {
     zelcashService.znsync(req, res);
   });
-  app.get('/zelcash/decodezelnodebroadcast/:hexstring?', cache('10 seconds'), (req, res) => {
+  app.get('/zelcash/decodezelnodebroadcast/:hexstring?', cache('30 seconds'), (req, res) => {
     zelcashService.decodeZelNodeBroadcast(req, res);
   });
   app.get('/zelcash/getzelnodecount', cache('30 seconds'), (req, res) => {
     zelcashService.getZelNodeCount(req, res);
   });
-  app.get('/zelcash/getdoslist', cache('1 minute'), (req, res) => {
+  app.get('/zelcash/getdoslist', cache('30 seconds'), (req, res) => {
     zelcashService.getDOSList(req, res);
   });
-  app.get('/zelcash/getstartlist', cache('1 minute'), (req, res) => {
+  app.get('/zelcash/getstartlist', cache('30 seconds'), (req, res) => {
     zelcashService.getStartList(req, res);
   });
-  app.get('/zelcash/getzelnodescores/:blocks?', (req, res) => { // defaults to 10
+  app.get('/zelcash/getzelnodescores/:blocks?', cache('30 seconds'), (req, res) => { // defaults to 10
     zelcashService.getZelNodeScores(req, res);
   });
-  app.get('/zelcash/getzelnodewinners/:blocks?/:filter?', (req, res) => {
+  app.get('/zelcash/getzelnodewinners/:blocks?/:filter?', cache('30 seconds'), (req, res) => {
     zelcashService.getZelNodeWinners(req, res);
   });
-  app.get('/zelcash/relayzelnodebroadcast/:hexstring?', (req, res) => {
+  app.get('/zelcash/relayzelnodebroadcast/:hexstring?', cache('30 seconds'), (req, res) => {
     zelcashService.relayZelNodeBroadcast(req, res);
   });
-  app.get('/zelcash/spork/:name?/:value?', (req, res) => {
+  app.get('/zelcash/spork/:name?/:value?', cache('30 seconds'), (req, res) => {
     zelcashService.spork(req, res);
   });
-  app.get('/zelcash/zelnodecurrentwinner', (req, res) => {
+  app.get('/zelcash/zelnodecurrentwinner', cache('30 seconds'), (req, res) => {
     zelcashService.zelNodeCurrentWinner(req, res);
   });
-  app.get('/zelcash/zelnodedebug', (req, res) => {
+  app.get('/zelcash/zelnodedebug', cache('30 seconds'), (req, res) => {
     zelcashService.zelNodeDebug(req, res);
   });
-  app.get('/zelcash/getbestblockhash', (req, res) => {
+  app.get('/zelcash/getbestblockhash', cache('30 seconds'), (req, res) => {
     zelcashService.getBestBlockHash(req, res);
   });
-  app.get('/zelcash/getblock/:hashheight?/:verbosity?', (req, res) => {
+  app.get('/zelcash/getblock/:hashheight?/:verbosity?', cache('30 seconds'), (req, res) => {
     zelcashService.getBlock(req, res);
   });
-  app.get('/zelcash/getblockchaininfo', (req, res) => {
+  app.get('/zelcash/getblockchaininfo', cache('30 seconds'), (req, res) => {
     zelcashService.getBlockchainInfo(req, res);
   });
-  app.get('/zelcash/getblockcount', (req, res) => {
+  app.get('/zelcash/getblockcount', cache('30 seconds'), (req, res) => {
     zelcashService.getBlockCount(req, res);
   });
-  app.get('/zelcash/getblockhash/:index?', (req, res) => {
+  app.get('/zelcash/getblockhash/:index?', cache('30 seconds'), (req, res) => {
     zelcashService.getBlockHash(req, res);
   });
-  app.get('/zelcash/getblockheader/:hash?/:verbose?', (req, res) => {
+  app.get('/zelcash/getblockheader/:hash?/:verbose?', cache('30 seconds'), (req, res) => {
     zelcashService.getBlockHeader(req, res);
   });
-  app.get('/zelcash/getchaintips', (req, res) => {
+  app.get('/zelcash/getchaintips', cache('30 seconds'), (req, res) => {
     zelcashService.getChainTips(req, res);
   });
-  app.get('/zelcash/getdifficulty', (req, res) => {
+  app.get('/zelcash/getdifficulty', cache('30 seconds'), (req, res) => {
     zelcashService.getDifficulty(req, res);
   });
-  app.get('/zelcash/getmempoolinfo', (req, res) => {
+  app.get('/zelcash/getmempoolinfo', cache('30 seconds'), (req, res) => {
     zelcashService.getMempoolInfo(req, res);
   });
-  app.get('/zelcash/getrawmempool/:verbose?', (req, res) => {
+  app.get('/zelcash/getrawmempool/:verbose?', cache('30 seconds'), (req, res) => {
     zelcashService.getRawMemPool(req, res);
   });
-  app.get('/zelcash/gettxout/:txid?/:n?/:includemempool?', (req, res) => {
+  app.get('/zelcash/gettxout/:txid?/:n?/:includemempool?', cache('30 seconds'), (req, res) => {
     zelcashService.getTxOut(req, res);
   });
-  app.get('/zelcash/gettxoutproof/:txids?/:blockhash?', (req, res) => { // comma separated list of txids. For example: /gettxoutproof/abc,efg,asd/blockhash
+  app.get('/zelcash/gettxoutproof/:txids?/:blockhash?', cache('30 seconds'), (req, res) => { // comma separated list of txids. For example: /gettxoutproof/abc,efg,asd/blockhash
     zelcashService.getTxOutProof(req, res);
   });
-  app.get('/zelcash/gettxoutsetinfo', (req, res) => {
+  app.get('/zelcash/gettxoutsetinfo', cache('30 seconds'), (req, res) => {
     zelcashService.getTxOutSetInfo(req, res);
   });
-  app.get('/zelcash/verifytxoutproof/:proof?', (req, res) => {
+  app.get('/zelcash/verifytxoutproof/:proof?', cache('30 seconds'), (req, res) => {
     zelcashService.verifyTxOutProof(req, res);
   });
-  app.get('/zelcash/getblocksubsidy/:height?', (req, res) => {
+  app.get('/zelcash/getblocksubsidy/:height?', cache('30 seconds'), (req, res) => {
     zelcashService.getBlockSubsidy(req, res);
   });
-  app.get('/zelcash/getblocktemplate/:jsonrequestobject?', (req, res) => {
+  app.get('/zelcash/getblocktemplate/:jsonrequestobject?', cache('30 seconds'), (req, res) => {
     zelcashService.getBlockTemplate(req, res);
   });
-  app.get('/zelcash/getlocalsolps', (req, res) => {
+  app.get('/zelcash/getlocalsolps', cache('30 seconds'), (req, res) => {
     zelcashService.getLocalSolPs(req, res);
   });
-  app.get('/zelcash/getmininginfo', (req, res) => {
+  app.get('/zelcash/getmininginfo', cache('30 seconds'), (req, res) => {
     zelcashService.getMiningInfo(req, res);
   });
-  app.get('/zelcash/getnetworkhashps/:blocks?/:height?', (req, res) => {
+  app.get('/zelcash/getnetworkhashps/:blocks?/:height?', cache('30 seconds'), (req, res) => {
     zelcashService.getNetworkHashPs(req, res);
   });
-  app.get('/zelcash/getnetworksolps/:blocks?/:height?', (req, res) => {
+  app.get('/zelcash/getnetworksolps/:blocks?/:height?', cache('30 seconds'), (req, res) => {
     zelcashService.getNetworkSolPs(req, res);
   });
-  app.get('/zelcash/getconnectioncount', (req, res) => {
+  app.get('/zelcash/getconnectioncount', cache('30 seconds'), (req, res) => {
     zelcashService.getConnectionCount(req, res);
   });
-  app.get('/zelcash/getdeprecationinfo', (req, res) => {
+  app.get('/zelcash/getdeprecationinfo', cache('30 seconds'), (req, res) => {
     zelcashService.getDeprecationInfo(req, res);
   });
-  app.get('/zelcash/getnettotals', (req, res) => {
+  app.get('/zelcash/getnettotals', cache('30 seconds'), (req, res) => {
     zelcashService.getNetTotals(req, res);
   });
-  app.get('/zelcash/getnetworkinfo', (req, res) => {
+  app.get('/zelcash/getnetworkinfo', cache('30 seconds'), (req, res) => {
     zelcashService.getNetworkInfo(req, res);
   });
-  app.get('/zelcash/getpeerinfo', (req, res) => {
+  app.get('/zelcash/getpeerinfo', cache('30 seconds'), (req, res) => {
     zelcashService.getPeerInfo(req, res);
   });
-  app.get('/zelcash/listbanned', (req, res) => {
+  app.get('/zelcash/listbanned', cache('30 seconds'), (req, res) => {
     zelcashService.listBanned(req, res);
   });
   app.get('/zelcash/createrawtransaction/:transactions?/:addresses?/:locktime?/:expiryheight?', (req, res) => {
     zelcashService.createRawTransaction(req, res);
   });
-  app.get('/zelcash/decoderawtransaction/:hexstring?', (req, res) => {
+  app.get('/zelcash/decoderawtransaction/:hexstring?', cache('30 seconds'), (req, res) => {
     zelcashService.decodeRawTransaction(req, res);
   });
-  app.get('/zelcash/decodescript/:hex?', (req, res) => {
+  app.get('/zelcash/decodescript/:hex?', cache('30 seconds'), (req, res) => {
     zelcashService.decodeScript(req, res);
   });
   app.get('/zelcash/fundrawtransaction/:hexstring?', (req, res) => {
@@ -159,28 +159,28 @@ module.exports = (app, expressWs) => {
   app.get('/zelcash/createmultisig/:n?/:keys?', (req, res) => {
     zelcashService.createMultiSig(req, res);
   });
-  app.get('/zelcash/estimatefee/:nblocks?', (req, res) => {
+  app.get('/zelcash/estimatefee/:nblocks?', cache('30 seconds'), (req, res) => {
     zelcashService.estimateFee(req, res);
   });
-  app.get('/zelcash/estimatepriority/:nblocks?', (req, res) => {
+  app.get('/zelcash/estimatepriority/:nblocks?', cache('30 seconds'), (req, res) => {
     zelcashService.estimatePriority(req, res);
   });
-  app.get('/zelcash/validateaddress/:zelcashaddress?', (req, res) => {
+  app.get('/zelcash/validateaddress/:zelcashaddress?', cache('30 seconds'), (req, res) => {
     zelcashService.validateAddress(req, res);
   });
-  app.get('/zelcash/verifymessage/:zelcashaddress?/:signature?/:message?', (req, res) => {
+  app.get('/zelcash/verifymessage/:zelcashaddress?/:signature?/:message?', cache('30 seconds'), (req, res) => {
     zelcashService.verifyMessage(req, res);
   });
-  app.get('/zelcash/gettransaction/:txid?/:includewatchonly?', (req, res) => {
+  app.get('/zelcash/gettransaction/:txid?/:includewatchonly?', cache('30 seconds'), (req, res) => {
     zelcashService.getTransaction(req, res);
   });
-  app.get('/zelcash/zvalidateaddress/:zaddr?', (req, res) => {
+  app.get('/zelcash/zvalidateaddress/:zaddr?', cache('30 seconds'), (req, res) => {
     zelcashService.zValidateAddress(req, res);
   });
-  app.get('/zelcash/getbenchmarks', (req, res) => {
+  app.get('/zelcash/getbenchmarks', cache('30 seconds'), (req, res) => {
     zelcashService.getBenchmarks(req, res);
   });
-  app.get('/zelcash/getbenchstatus', (req, res) => {
+  app.get('/zelcash/getbenchstatus', cache('30 seconds'), (req, res) => {
     zelcashService.getBenchStatus(req, res);
   });
 
@@ -191,98 +191,98 @@ module.exports = (app, expressWs) => {
     zelidService.emergencyPhrase(req, res);
   });
 
-  app.get('/zelflux/info', (req, res) => {
+  app.get('/zelflux/info', cache('30 seconds'), (req, res) => {
     zelnodeService.getZelFluxInfo(req, res);
   });
   app.get('/zelflux/timezone', (req, res) => {
     zelnodeService.getZelFluxTimezone(req, res);
   });
-  app.get('/zelflux/version', (req, res) => {
+  app.get('/zelflux/version', cache('30 seconds'), (req, res) => {
     zelnodeService.getZelFluxVersion(req, res);
   });
-  app.get('/zelflux/ip', (req, res) => {
+  app.get('/zelflux/ip', cache('30 seconds'), (req, res) => {
     zelnodeService.getZelFluxIP(req, res);
   });
-  app.get('/zelflux/zelid', (req, res) => {
+  app.get('/zelflux/zelid', cache('30 seconds'), cache('30 seconds'), (req, res) => {
     zelnodeService.getZelFluxZelID(req, res);
   });
-  app.get('/zelflux/cruxid', (req, res) => {
+  app.get('/zelflux/cruxid', cache('30 seconds'), (req, res) => {
     zelnodeService.getZelFluxCruxID(req, res);
   });
-  app.get('/zelflux/dosstate', (req, res) => {
+  app.get('/zelflux/dosstate', cache('30 seconds'), (req, res) => {
     zelfluxCommunication.getDOSState(req, res);
   });
-  app.get('/zelflux/connectedpeers', (req, res) => {
+  app.get('/zelflux/connectedpeers', cache('30 seconds'), (req, res) => {
     zelfluxCommunication.connectedPeers(req, res);
   });
-  app.get('/zelflux/connectedpeersinfo', (req, res) => {
+  app.get('/zelflux/connectedpeersinfo', cache('30 seconds'), (req, res) => {
     zelfluxCommunication.connectedPeersInfo(req, res);
   });
-  app.get('/zelflux/incomingconnections', (req, res) => {
+  app.get('/zelflux/incomingconnections', cache('30 seconds'), (req, res) => {
     zelfluxCommunication.getIncomingConnections(req, res, expressWs.getWss('/ws/zelflux'));
   });
-  app.get('/zelflux/incomingconnectionsinfo', (req, res) => {
+  app.get('/zelflux/incomingconnectionsinfo', cache('30 seconds'), (req, res) => {
     zelfluxCommunication.getIncomingConnectionsInfo(req, res, expressWs.getWss('/ws/zelflux'));
   });
-  app.get('/zelflux/checkfluxavailability/:ip?', (req, res) => {
+  app.get('/zelflux/checkfluxavailability/:ip?', cache('30 seconds'), (req, res) => {
     zelfluxCommunication.checkFluxAvailability(req, res);
   });
 
-  app.get('/zelapps/listrunningzelapps', (req, res) => {
+  app.get('/zelapps/listrunningzelapps', cache('30 seconds'), (req, res) => {
     zelappsService.listRunningZelApps(req, res);
   });
-  app.get('/zelapps/listallzelapps', (req, res) => {
+  app.get('/zelapps/listallzelapps', cache('30 seconds'), (req, res) => {
     zelappsService.listAllZelApps(req, res);
   });
-  app.get('/zelapps/listzelappsimages', (req, res) => {
+  app.get('/zelapps/listzelappsimages', cache('30 seconds'), (req, res) => {
     zelappsService.listZelAppsImages(req, res);
   });
-  app.get('/zelapps/installedzelapps/:appname?', (req, res) => {
+  app.get('/zelapps/installedzelapps/:appname?', cache('30 seconds'), (req, res) => {
     zelappsService.installedZelApps(req, res);
   });
-  app.get('/zelapps/availablezelapps', (req, res) => {
+  app.get('/zelapps/availablezelapps', cache('30 seconds'), (req, res) => {
     zelappsService.availableZelApps(req, res);
   });
-  app.get('/zelapps/zelfluxusage', (req, res) => {
+  app.get('/zelapps/zelfluxusage', cache('30 seconds'), (req, res) => {
     zelappsService.zelFluxUsage(req, res);
   });
-  app.get('/zelapps/zelappsresources', (req, res) => {
+  app.get('/zelapps/zelappsresources', cache('30 seconds'), (req, res) => {
     zelappsService.zelappsResources(req, res);
   });
-  app.get('/zelapps/registrationinformation', (req, res) => {
+  app.get('/zelapps/registrationinformation', cache('30 seconds'), (req, res) => {
     zelappsService.registrationInformation(req, res);
   });
-  app.get('/zelapps/temporarymessages', (req, res) => {
+  app.get('/zelapps/temporarymessages', cache('30 seconds'), (req, res) => {
     zelappsService.getZelAppsTemporaryMessages(req, res);
   });
-  app.get('/zelapps/permanentmessages', (req, res) => {
+  app.get('/zelapps/permanentmessages', cache('30 seconds'), (req, res) => {
     zelappsService.getZelAppsPermanentMessages(req, res);
   });
-  app.get('/zelapps/globalappsspecifications', (req, res) => {
+  app.get('/zelapps/globalappsspecifications', cache('30 seconds'), (req, res) => {
     zelappsService.getGlobalZelAppsSpecifications(req, res);
   });
-  app.get('/zelapps/appspecifications/:appname?', (req, res) => {
+  app.get('/zelapps/appspecifications/:appname?', cache('30 seconds'), (req, res) => {
     zelappsService.getApplicationSpecificationAPI(req, res);
   });
-  app.get('/zelapps/appowner/:appname?', (req, res) => {
+  app.get('/zelapps/appowner/:appname?', cache('30 seconds'), (req, res) => {
     zelappsService.getApplicationOwnerAPI(req, res);
   });
-  app.get('/zelapps/hashes', (req, res) => {
+  app.get('/zelapps/hashes', cache('30 seconds'), (req, res) => {
     zelappsService.getZelAppHashes(req, res);
   });
-  app.get('/zelapps/location/:appname?', (req, res) => {
+  app.get('/zelapps/location/:appname?', cache('30 seconds'), (req, res) => {
     zelappsService.getZelAppsLocation(req, res);
   });
-  app.get('/zelapps/locations', (req, res) => {
+  app.get('/zelapps/locations', cache('30 seconds'), (req, res) => {
     zelappsService.getZelAppsLocations(req, res);
   });
   app.post('/zelapps/calculateprice', (req, res) => { // returns price in zel for both new registration of zelapp and update of zelapp
     zelappsService.getAppPrice(req, res);
   });
-  app.get('/zelapps/whitelistedrepositories', (req, res) => {
+  app.get('/zelapps/whitelistedrepositories', cache('30 seconds'), (req, res) => {
     zelappsService.whitelistedRepositories(req, res);
   });
-  app.get('/zelapps/whitelistedzelids', (req, res) => {
+  app.get('/zelapps/whitelistedzelids', cache('30 seconds'), (req, res) => {
     zelappsService.whitelistedZelIDs(req, res);
   });
 
@@ -299,50 +299,50 @@ module.exports = (app, expressWs) => {
   //   explorerService.getAllZelNodeTransactions(req, res);
   // });
   // filter can be IP, address, collateralHash.
-  app.get('/explorer/zelnodetxs/:filter?', (req, res) => {
+  app.get('/explorer/zelnodetxs/:filter?', cache('30 seconds'), (req, res) => {
     explorerService.getFilteredZelNodeTxs(req, res);
   });
-  app.get('/explorer/utxo/:address?', (req, res) => {
+  app.get('/explorer/utxo/:address?', cache('30 seconds'), (req, res) => {
     explorerService.getAddressUtxos(req, res);
   });
-  app.get('/explorer/transactions/:address?', (req, res) => {
+  app.get('/explorer/transactions/:address?', cache('30 seconds'), (req, res) => {
     explorerService.getAddressTransactions(req, res);
   });
-  app.get('/explorer/balance/:address?', (req, res) => {
+  app.get('/explorer/balance/:address?', cache('30 seconds'), (req, res) => {
     explorerService.getAddressBalance(req, res);
   });
-  app.get('/explorer/scannedheight', (req, res) => {
+  app.get('/explorer/scannedheight', cache('30 seconds'), (req, res) => {
     explorerService.getScannedHeight(req, res);
   });
 
   // GET PROTECTED API - User level
-  app.get('/zelcash/prioritisetransaction/:txid?/:prioritydelta?/:feedelta?', (req, res) => {
+  app.get('/zelcash/prioritisetransaction/:txid?/:prioritydelta?/:feedelta?', cache('30 seconds'), (req, res) => {
     zelcashService.prioritiseTransaction(req, res);
   });
-  app.get('/zelcash/submitblock/:hexdata?/:jsonparametersobject?', (req, res) => {
+  app.get('/zelcash/submitblock/:hexdata?/:jsonparametersobject?', cache('30 seconds'), (req, res) => {
     zelcashService.submitBlock(req, res);
   });
 
-  app.get('/zelid/loggedsessions', (req, res) => {
+  app.get('/zelid/loggedsessions', cache('30 seconds'), (req, res) => {
     zelidService.loggedSessions(req, res);
   });
-  app.get('/zelid/logoutcurrentsession', (req, res) => {
+  app.get('/zelid/logoutcurrentsession', cache('30 seconds'), (req, res) => {
     zelidService.logoutCurrentSession(req, res);
   });
-  app.get('/zelid/logoutallsessions', (req, res) => {
+  app.get('/zelid/logoutallsessions', cache('30 seconds'), (req, res) => {
     zelidService.logoutAllSessions(req, res);
   });
 
-  app.get('/zelbench/getstatus', (req, res) => {
+  app.get('/zelbench/getstatus', cache('30 seconds'), (req, res) => {
     zelbenchService.getStatus(req, res);
   });
-  app.get('/zelbench/help/:command?', (req, res) => {
+  app.get('/zelbench/help/:command?', cache('1 hour'), (req, res) => {
     zelbenchService.help(req, res);
   });
-  app.get('/zelbench/getbenchmarks', (req, res) => {
+  app.get('/zelbench/getbenchmarks', cache('30 seconds'), (req, res) => {
     zelbenchService.getBenchmarks(req, res);
   });
-  app.get('/zelbench/getinfo', (req, res) => {
+  app.get('/zelbench/getinfo', cache('30 seconds'), (req, res) => {
     zelbenchService.getInfo(req, res);
   });
 

--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -1,3 +1,5 @@
+const apicache = require('apicache');
+
 const zelcashService = require('./services/zelcashService');
 const zelbenchService = require('./services/zelbenchService');
 const zelidService = require('./services/zelidService');
@@ -6,36 +8,38 @@ const zelfluxCommunication = require('./services/zelfluxCommunication');
 const zelappsService = require('./services/zelappsService');
 const explorerService = require('./services/explorerService');
 
+const cache = apicache.middleware;
+
 module.exports = (app, expressWs) => {
   // GET PUBLIC methods
-  app.get('/zelcash/help/:command?', (req, res) => { // accept both help/command and ?command=getinfo. If ommited, default help will be displayed. Other calls works in similar way
+  app.get('/zelcash/help/:command?', cache('1 minute'), (req, res) => { // accept both help/command and ?command=getinfo. If ommited, default help will be displayed. Other calls works in similar way
     zelcashService.help(req, res);
   });
-  app.get('/zelcash/getinfo', (req, res) => {
+  app.get('/zelcash/getinfo', cache('10 seconds'), (req, res) => {
     zelcashService.getInfo(req, res);
   });
-  app.get('/zelcash/getzelnodestatus', (req, res) => {
+  app.get('/zelcash/getzelnodestatus', cache('10 seconds'), (req, res) => {
     zelcashService.getZelNodeStatus(req, res);
   });
-  app.get('/zelcash/listzelnodes/:filter?', (req, res) => {
+  app.get('/zelcash/listzelnodes/:filter?', cache('10 seconds'), (req, res) => {
     zelcashService.listZelNodes(req, res);
   });
-  app.get('/zelcash/viewdeterministiczelnodelist/:filter?', (req, res) => {
+  app.get('/zelcash/viewdeterministiczelnodelist/:filter?', cache('10 seconds'), (req, res) => {
     zelcashService.viewDeterministicZelNodeList(req, res);
   });
-  app.get('/zelcash/znsync/:mode?', (req, res) => {
+  app.get('/zelcash/znsync/:mode?', cache('1 minute'), (req, res) => {
     zelcashService.znsync(req, res);
   });
-  app.get('/zelcash/decodezelnodebroadcast/:hexstring?', (req, res) => {
+  app.get('/zelcash/decodezelnodebroadcast/:hexstring?', cache('10 seconds'), (req, res) => {
     zelcashService.decodeZelNodeBroadcast(req, res);
   });
-  app.get('/zelcash/getzelnodecount', (req, res) => {
+  app.get('/zelcash/getzelnodecount', cache('30 seconds'), (req, res) => {
     zelcashService.getZelNodeCount(req, res);
   });
-  app.get('/zelcash/getdoslist', (req, res) => {
+  app.get('/zelcash/getdoslist', cache('1 minute'), (req, res) => {
     zelcashService.getDOSList(req, res);
   });
-  app.get('/zelcash/getstartlist', (req, res) => {
+  app.get('/zelcash/getstartlist', cache('1 minute'), (req, res) => {
     zelcashService.getStartList(req, res);
   });
   app.get('/zelcash/getzelnodescores/:blocks?', (req, res) => { // defaults to 10

--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -846,7 +846,7 @@ module.exports = (app, expressWs) => {
   });
 
   // ZelShare
-  app.get('/zelapps/zelshare/getfile/:file?', (req, res) => {
+  app.get('/zelapps/zelshare/getfile/:file?/:hash?', (req, res) => {
     zelappsService.zelShareFile(req, res);
   });
   app.get('/zelapps/zelshare/getfolder/:folder?', (req, res) => {
@@ -869,5 +869,14 @@ module.exports = (app, expressWs) => {
   });
   app.get('/zelapps/zelshare/stats', (req, res) => {
     zelappsService.zelShareStorageStats(req, res);
+  });
+  app.get('/zelapps/zelshare/sharefile/:file?', (req, res) => {
+    zelappsService.zelShareShareFile(req, res);
+  });
+  app.get('/zelapps/zelshare/unsharefile/:file?', (req, res) => {
+    zelappsService.zelShareUnshareFile(req, res);
+  });
+  app.get('/zelapps/zelshare/sharedfiles', (req, res) => {
+    zelappsService.zelShareGetSharedFiles(req, res);
   });
 };

--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -239,9 +239,6 @@ module.exports = (app, expressWs) => {
   app.get('/zelapps/availablezelapps', (req, res) => {
     zelappsService.availableZelApps(req, res);
   });
-  app.get('/zelapps/zelshare/getfile/:file?', (req, res) => {
-    zelappsService.zelShareFile(req, res);
-  });
   app.get('/zelapps/zelfluxusage', (req, res) => {
     zelappsService.zelFluxUsage(req, res);
   });
@@ -842,5 +839,13 @@ module.exports = (app, expressWs) => {
   // communication between multiple zelflux solution is on this:
   app.ws('/ws/zelflux', (ws, req) => {
     zelfluxCommunication.handleIncomingConnection(ws, req, expressWs.getWss('/ws/zelflux'));
+  });
+
+  // ZelShare
+  app.get('/zelapps/zelshare/getfile/:file?', (req, res) => {
+    zelappsService.zelShareFile(req, res);
+  });
+  app.post('/zelapps/zelshare/uploadfile', (req, res) => {
+    zelappsService.zelShareFile(req, res);
   });
 };

--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -854,4 +854,7 @@ module.exports = (app, expressWs) => {
   app.post('/zelapps/zelshare/uploadfile/:folder?', (req, res) => {
     zelappsService.zelShareUpload(req, res);
   });
+  app.get('/zelapps/zelshare/removefile/:file?', (req, res) => {
+    zelappsService.zelShareRemoveFile(req, res);
+  });
 };

--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -846,7 +846,7 @@ module.exports = (app, expressWs) => {
   });
 
   // ZelShare
-  app.get('/zelapps/zelshare/getfile/:file?/:hash?', (req, res) => {
+  app.get('/zelapps/zelshare/getfile/:file?/:token?', (req, res) => {
     zelappsService.zelShareFile(req, res);
   });
   app.get('/zelapps/zelshare/getfolder/:folder?', (req, res) => {

--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -860,4 +860,7 @@ module.exports = (app, expressWs) => {
   app.get('/zelapps/zelshare/removefolder/:folder?', (req, res) => {
     zelappsService.zelShareRemoveFolder(req, res);
   });
+  app.get('/zelapps/zelshare/fileexists/:file?', (req, res) => {
+    zelappsService.zelShareFileExists(req, res);
+  });
 };

--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -857,4 +857,7 @@ module.exports = (app, expressWs) => {
   app.get('/zelapps/zelshare/removefile/:file?', (req, res) => {
     zelappsService.zelShareRemoveFile(req, res);
   });
+  app.get('/zelapps/zelshare/removefolder/:folder?', (req, res) => {
+    zelappsService.zelShareRemoveFolder(req, res);
+  });
 };

--- a/ZelBack/src/routes.js
+++ b/ZelBack/src/routes.js
@@ -845,7 +845,13 @@ module.exports = (app, expressWs) => {
   app.get('/zelapps/zelshare/getfile/:file?', (req, res) => {
     zelappsService.zelShareFile(req, res);
   });
-  app.post('/zelapps/zelshare/uploadfile', (req, res) => {
-    zelappsService.zelShareFile(req, res);
+  app.get('/zelapps/zelshare/getfolder/:folder?', (req, res) => {
+    zelappsService.zelShareGetFolder(req, res);
+  });
+  app.get('/zelapps/zelshare/createfolder/:folder?', (req, res) => {
+    zelappsService.zelShareCreateFolder(req, res);
+  });
+  app.post('/zelapps/zelshare/uploadfile/:folder?', (req, res) => {
+    zelappsService.zelShareUpload(req, res);
   });
 };

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -4787,6 +4787,43 @@ async function zelShareRemoveFile(req, res) {
   }
 }
 
+async function zelShareRemoveFolder(req, res) {
+  try {
+    const authorized = await serviceHelper.verifyPrivilege('admin', req);
+    if (authorized) {
+      let { folder } = req.params;
+      folder = folder || req.query.folder;
+      folder = decodeURIComponent(folder);
+      if (!folder) {
+        throw new Error('No folder specified');
+      }
+
+      const dirpath = path.join(__dirname, '../../../');
+      const filepath = `${dirpath}ZelApps/ZelShare/${folder}`;
+      await fs.promises.rmdir(filepath);
+
+      const response = serviceHelper.createSuccessMessage('Folder Removed');
+      res.json(response);
+    } else {
+      const errMessage = serviceHelper.errUnauthorizedMessage();
+      res.json(errMessage);
+    }
+  } catch (error) {
+    log.error(error);
+    const errorResponse = serviceHelper.createErrorMessage(
+      error.message || error,
+      error.name,
+      error.code,
+    );
+    try {
+      res.write(serviceHelper.ensureString(errorResponse));
+      res.end();
+    } catch (e) {
+      log.error(e);
+    }
+  }
+}
+
 async function zelShareGetFolder(req, res) {
   try {
     const authorized = await serviceHelper.verifyPrivilege('admin', req);
@@ -5034,6 +5071,7 @@ module.exports = {
   zelShareCreateFolder,
   zelShareUpload,
   zelShareRemoveFile,
+  zelShareRemoveFolder,
 };
 
 // reenable min connections for registrations/updates before main release

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -4729,6 +4729,43 @@ async function zelShareFile(req, res) {
   return res.sendFile(filepath);
 }
 
+async function zelShareRemoveFile(req, res) {
+  try {
+    const authorized = await serviceHelper.verifyPrivilege('admin', req);
+    if (authorized) {
+      let { file } = req.params;
+      file = file || req.query.file;
+      file = decodeURIComponent(file);
+      if (!file) {
+        throw new Error('No file specified');
+      }
+
+      const dirpath = path.join(__dirname, '../../../');
+      const filepath = `${dirpath}ZelApps/ZelShare/${file}`;
+      await fs.promises.unlink(filepath);
+
+      const response = serviceHelper.createSuccessMessage('File Removed');
+      res.json(response);
+    } else {
+      const errMessage = serviceHelper.errUnauthorizedMessage();
+      res.json(errMessage);
+    }
+  } catch (error) {
+    log.error(error);
+    const errorResponse = serviceHelper.createErrorMessage(
+      error.message || error,
+      error.name,
+      error.code,
+    );
+    try {
+      res.write(serviceHelper.ensureString(errorResponse));
+      res.end();
+    } catch (e) {
+      log.error(e);
+    }
+  }
+}
+
 async function zelShareGetFolder(req, res) {
   try {
     let { folder } = req.params;
@@ -4962,6 +4999,7 @@ module.exports = {
   zelShareGetFolder,
   zelShareCreateFolder,
   zelShareUpload,
+  zelShareRemoveFile,
 };
 
 // reenable min connections for registrations/updates before main release

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -4888,7 +4888,6 @@ async function zelShareFile(req, res) {
     if (authorized) {
       let { file } = req.params;
       file = file || req.query.file;
-      file = decodeURIComponent(file);
 
       const dirpath = path.join(__dirname, '../../../');
       const filepath = `${dirpath}ZelApps/ZelShare/${file}`;
@@ -4904,10 +4903,11 @@ async function zelShareFile(req, res) {
         res.json(errMessage);
         return;
       }
+      const fileURI = encodeURIComponent(file);
       const dbopen = serviceHelper.databaseConnection();
       const databaseZelShare = dbopen.db(config.database.zelshare.database);
       const sharedCollection = config.database.zelshare.collections.shared;
-      const queryZelShare = { name: file, hash };
+      const queryZelShare = { name: fileURI, hash };
       const projectionZelShare = { projection: { _id: 0, name: 1, hash: 1 } };
       const result = await serviceHelper.findOneInDatabase(databaseZelShare, sharedCollection, queryZelShare, projectionZelShare);
       if (!result) {
@@ -4915,7 +4915,6 @@ async function zelShareFile(req, res) {
         res.json(errMessage);
         return;
       }
-      file = decodeURIComponent(file);
 
       const dirpath = path.join(__dirname, '../../../');
       const filepath = `${dirpath}ZelApps/ZelShare/${file}`;
@@ -4945,7 +4944,6 @@ async function zelShareRemoveFile(req, res) {
       let { file } = req.params;
       file = file || req.query.file;
       const fileURI = encodeURIComponent(file);
-      file = decodeURIComponent(file);
       if (!file) {
         throw new Error('No file specified');
       }
@@ -4985,7 +4983,6 @@ async function zelShareRemoveFolder(req, res) {
     if (authorized) {
       let { folder } = req.params;
       folder = folder || req.query.folder;
-      folder = decodeURIComponent(folder);
       if (!folder) {
         throw new Error('No folder specified');
       }
@@ -5022,7 +5019,6 @@ async function zelShareGetFolder(req, res) {
     if (authorized) {
       let { folder } = req.params;
       folder = folder || req.query.folder || '';
-      folder = decodeURIComponent(folder);
 
       const dirpath = path.join(__dirname, '../../../');
       const filepath = `${dirpath}ZelApps/ZelShare/${folder}`;
@@ -5082,7 +5078,6 @@ async function zelShareCreateFolder(req, res) {
     if (authorized) {
       let { folder } = req.params;
       folder = folder || req.query.folder || '';
-      folder = decodeURIComponent(folder);
 
       const dirpath = path.join(__dirname, '../../../');
       const filepath = `${dirpath}ZelApps/ZelShare/${folder}`;
@@ -5108,7 +5103,6 @@ async function zelShareFileExists(req, res) {
     if (authorized) {
       let { file } = req.params;
       file = file || req.query.file;
-      file = decodeURIComponent(file);
 
       const dirpath = path.join(__dirname, '../../../');
       const filepath = `${dirpath}ZelApps/ZelShare/${file}`;
@@ -5257,7 +5251,6 @@ async function zelShareUpload(req, res) {
     }
     let { folder } = req.params;
     folder = folder || req.query.folder || '';
-    folder = decodeURIComponent(folder);
     if (folder) {
       folder += '/';
     }

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -2596,8 +2596,9 @@ async function storeZelAppTemporaryMessage(message, furtherVerification = false)
   }
   // check if we have the message in cache. If yes, return false. If not, store it and continue
   if (myCache.has(serviceHelper.ensureString(message))) {
-    return 0;
+    return false;
   }
+  console.log(message);
   myCache.set(serviceHelper.ensureString(message), message);
   // data shall already be verified by the broadcasting node. But verify all again.
   if (furtherVerification) {
@@ -2683,6 +2684,7 @@ async function storeZelAppRunningMessage(message) {
   if (myCache.has(serviceHelper.ensureString(message))) {
     return false;
   }
+  console.log(message);
   myCache.set(serviceHelper.ensureString(message), message);
 
   const validTill = message.broadcastedAt + (65 * 60 * 1000); // 3900 seconds

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -5003,7 +5003,7 @@ async function getSpaceAvailableForZelShare() {
   return spaceAvailableForZelShare;
 }
 
-async function zelShareSpaceAvailableTotal(req, res) {
+async function zelShareStorageStats(req, res) {
   try {
     const authorized = await serviceHelper.verifyPrivilege('admin', req);
     if (authorized) {
@@ -5212,7 +5212,7 @@ module.exports = {
   zelShareRemoveFile,
   zelShareRemoveFolder,
   zelShareFileExists,
-  zelShareSpaceAvailableTotal,
+  zelShareStorageStats,
 };
 
 // reenable min connections for registrations/updates before main release

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -5202,18 +5202,15 @@ async function getSpaceAvailableForZelShare() {
   console.log(okVolumes);
 
   // now we know that most likely there is a space available. IF user does not have his own stuff on the node or space may be sharded accross hdds.
-  let availableSpace = 0;
+  let totalSpace = 0;
   okVolumes.forEach((volume) => {
-    availableSpace += serviceHelper.ensureNumber(volume.available);
+    totalSpace += serviceHelper.ensureNumber(volume.size);
   });
   // space that is further reserved for zelflux os and that will be later substracted from available space. Max 30.
   const tier = await zelnodeTier();
   const lockedSpaceOnNode = config.fluxSpecifics.hdd[tier];
 
-  const resourcesLocked = await zelappsResources();
-  const hddLockedByApps = resourcesLocked.data.zelAppsHddLocked; // as this does not count since its loop
-
-  const extraSpaceOnNode = availableSpace - lockedSpaceOnNode + hddLockedByApps > 0 ? availableSpace - lockedSpaceOnNode + hddLockedByApps : 0; // shall always be above 0. Put precaution to place anyway
+  const extraSpaceOnNode = totalSpace - lockedSpaceOnNode > 0 ? totalSpace - lockedSpaceOnNode : 0; // shall always be above 0. Put precaution to place anyway
   // const extraSpaceOnNode = availableSpace - lockedSpaceOnNode > 0 ? availableSpace - lockedSpaceOnNode : 0;
   const spaceAvailableForZelShare = 2 + extraSpaceOnNode;
   return spaceAvailableForZelShare;

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -4807,7 +4807,11 @@ async function zelShareUpload(req, res) {
       hash: true,
       keepExtensions: true,
     };
+    await fs.promises.access(uploadDir); // check folder exists
     const form = formidable(options);
+    form.on('error', () => {
+      throw new Error('formidable path error');
+    });
     form.parse(req)
       .on('fileBegin', (name, file) => {
         console.log(name);

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -4944,7 +4944,13 @@ function getAllFiles(dirPath, arrayOfFiles) {
   arrayOfFiles = arrayOfFiles || [];
 
   files.forEach((file) => {
-    if (fs.statSync(`${dirPath}/${file}`).isDirectory()) {
+    let isDirectory = false;
+    try {
+      isDirectory = fs.statSync(`${dirPath}/${file}`).isDirectory();
+    } catch (error) {
+      log.warn(error);
+    }
+    if (isDirectory) {
       // eslint-disable-next-line no-param-reassign
       arrayOfFiles = getAllFiles(`${dirPath}/${file}`, arrayOfFiles);
     } else {
@@ -4963,7 +4969,11 @@ function getZelShareSize() {
   let totalSize = 0;
 
   arrayOfFiles.forEach((filePath) => {
-    totalSize += fs.statSync(filePath).size;
+    try {
+      totalSize += fs.statSync(filePath).size;
+    } catch (error) {
+      log.warn(error);
+    }
   });
   return (totalSize / 1e9); // in 'GB'
 }

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -2356,10 +2356,10 @@ async function availableZelApps(req, res) {
       ram: 4000, // true resource registered for app
       hdd: 40, // true resource registered for app
       enviromentParameters: ['CHAINWEB_PORT=30004', 'LOGLEVEL=warn'],
-      commands: [],
+      commands: ['/bin/bash', '-c', '(test -d /data/chainweb-db/0 && ./run-chainweb-node.sh) || (/chainweb/initialize-db.sh && ./run-chainweb-node.sh)'],
       containerPort: 30004,
       containerData: '/data', // cannot be root todo in verification
-      hash: 'localSpecificationsVersion1', // hash of app message
+      hash: 'localSpecificationsVersion2', // hash of app message
       height: 680000, // height of tx on which it was
     },
   ];

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -4855,14 +4855,9 @@ async function zelShareUpload(req, res) {
       });
   } catch (error) {
     log.error(error);
-    const errorResponse = serviceHelper.createErrorMessage(
-      error.message || error,
-      error.name,
-      error.code,
-    );
     if (res) {
-      res.write(serviceHelper.ensureString(errorResponse));
-      res.end();
+      // res.set('Connection', 'close');
+      res.connection.destroy();
     }
   }
 }

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -4954,7 +4954,7 @@ function getAllFiles(dirPath, arrayOfFiles) {
       // eslint-disable-next-line no-param-reassign
       arrayOfFiles = getAllFiles(`${dirPath}/${file}`, arrayOfFiles);
     } else {
-      arrayOfFiles.push(path.join(__dirname, dirPath, file));
+      arrayOfFiles.push(`${dirPath}/${file}`);
     }
   });
   return arrayOfFiles;
@@ -5008,7 +5008,12 @@ async function getSpaceAvailableForZelShare() {
   // space that is further reserved for zelflux os and that will be later substracted from available space. Max 30.
   const tier = await zelnodeTier();
   const lockedSpaceOnNode = config.fluxSpecifics.hdd[tier];
-  const extraSpaceOnNode = availableSpace - lockedSpaceOnNode > 0 ? availableSpace - lockedSpaceOnNode : 0; // shall always be above 0. Put precaution to place anyway
+
+  const resourcesLocked = await zelappsResources();
+  const hddLockedByApps = resourcesLocked.data.zelAppsHddLocked; // as this does not count since its loop
+
+  const extraSpaceOnNode = availableSpace - lockedSpaceOnNode + hddLockedByApps > 0 ? availableSpace - lockedSpaceOnNode + hddLockedByApps : 0; // shall always be above 0. Put precaution to place anyway
+  // const extraSpaceOnNode = availableSpace - lockedSpaceOnNode > 0 ? availableSpace - lockedSpaceOnNode : 0;
   const spaceAvailableForZelShare = 2 + extraSpaceOnNode;
   return spaceAvailableForZelShare;
 }

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -4827,6 +4827,7 @@ async function zelShareUnshareFile(req, res) {
     if (authorized) {
       let { file } = req.params;
       file = file || req.query.file;
+      file = encodeURIComponent(file);
       await zelShareDatabaseFileDelete(file);
       const resultsResponse = serviceHelper.createSuccessMessage('File sharing disabled');
       res.json(resultsResponse);
@@ -4856,6 +4857,7 @@ async function zelShareShareFile(req, res) {
     if (authorized) {
       let { file } = req.params;
       file = file || req.query.file;
+      file = encodeURIComponent(file);
       const fileDetails = await zelShareDatabaseShareFile(file);
       const resultsResponse = serviceHelper.createDataMessage(fileDetails);
       res.json(resultsResponse);
@@ -4942,12 +4944,13 @@ async function zelShareRemoveFile(req, res) {
     if (authorized) {
       let { file } = req.params;
       file = file || req.query.file;
-      const fileURI = file;
+      const fileURI = encodeURIComponent(file);
       file = decodeURIComponent(file);
       if (!file) {
         throw new Error('No file specified');
       }
       // stop sharing
+
       await zelShareDatabaseFileDelete(fileURI);
 
       const dirpath = path.join(__dirname, '../../../');

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -4861,7 +4861,6 @@ async function zelShareCreateFolder(req, res) {
 
 async function zelShareUpload(req, res) {
   try {
-    console.log(req.headers);
     const authorized = await serviceHelper.verifyPrivilege('admin', req);
     if (!authorized) {
       throw new Error('Unauthorized. Access denied.');
@@ -4887,8 +4886,6 @@ async function zelShareUpload(req, res) {
     form.parse(req)
       .on('fileBegin', (name, file) => {
         try {
-          console.log(name);
-          console.log(file);
           res.write(serviceHelper.ensureString(file.name));
           const filepath = `${dirpath}ZelApps/ZelShare/${folder}${file.name}`;
           // eslint-disable-next-line no-param-reassign

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -4812,16 +4812,24 @@ async function zelShareUpload(req, res) {
     const form = formidable(options);
     form.parse(req)
       .on('fileBegin', (name, file) => {
-        console.log(name);
-        console.log(file);
-        res.write(serviceHelper.ensureString(file.name));
-        const filepath = `${dirpath}ZelApps/ZelShare/${folder}${file.name}`;
-        // eslint-disable-next-line no-param-reassign
-        file.path = filepath;
+        try {
+          console.log(name);
+          console.log(file);
+          res.write(serviceHelper.ensureString(file.name));
+          const filepath = `${dirpath}ZelApps/ZelShare/${folder}${file.name}`;
+          // eslint-disable-next-line no-param-reassign
+          file.path = filepath;
+        } catch (error) {
+          log.error(error);
+        }
       })
       .on('progress', (bytesReceived, bytesExpected) => {
-        // console.log('PROGRESS');
-        res.write(serviceHelper.ensureString([bytesReceived, bytesExpected]));
+        try {
+          // console.log('PROGRESS');
+          res.write(serviceHelper.ensureString([bytesReceived, bytesExpected]));
+        } catch (error) {
+          log.error(error);
+        }
       })
       .on('field', (name, field) => {
         console.log('Field', name, field);
@@ -4830,34 +4838,46 @@ async function zelShareUpload(req, res) {
         // res.write(serviceHelper.ensureString(field));
       })
       .on('file', (name, file) => {
-        // console.log('Uploaded file', name, file);
-        res.write(serviceHelper.ensureString(file));
+        try {
+          // console.log('Uploaded file', name, file);
+          res.write(serviceHelper.ensureString(file));
+        } catch (error) {
+          log.error(error);
+        }
       })
       .on('aborted', () => {
         console.error('Request aborted by the user');
-        if (res) {
-          res.end();
-        }
       })
       .on('error', (error) => {
+        log.error(error);
         const errorResponse = serviceHelper.createErrorMessage(
           error.message || error,
           error.name,
           error.code,
         );
-        if (res) {
+        try {
           res.write(serviceHelper.ensureString(errorResponse));
           res.end();
+        } catch (e) {
+          log.error(e);
         }
       })
       .on('end', () => {
-        res.end();
+        try {
+          res.end();
+        } catch (error) {
+          log.error(error);
+        }
       });
   } catch (error) {
     log.error(error);
     if (res) {
       // res.set('Connection', 'close');
-      res.connection.destroy();
+      try {
+        res.connection.destroy();
+      } catch (e) {
+        log.error(e);
+      }
     }
   }
 }

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -4764,10 +4764,11 @@ async function zelShareDatabaseShareFile(file) {
     if (result) {
       return result;
     }
+    const string = file + new Date().getTime().toString() + Math.floor((Math.random() * 999999999999999)).toString();
 
     const fileDetail = {
       name: file,
-      token: crypto.createHash('sha256').update(file + new Date().getTime() + Math.floor((Math.random() * 999999999999999))).digest('hex'),
+      token: crypto.createHash('sha256').update(string).digest('hex'),
     };
     // put the utxo to our mongoDB utxoIndex collection.
     await serviceHelper.insertOneToDatabase(databaseZelShare, sharedCollection, fileDetail);

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -2598,7 +2598,7 @@ async function storeZelAppTemporaryMessage(message, furtherVerification = false)
   if (myCache.has(serviceHelper.ensureString(message))) {
     return false;
   }
-  console.log(message);
+  console.log(serviceHelper.ensureString(message));
   myCache.set(serviceHelper.ensureString(message), message);
   // data shall already be verified by the broadcasting node. But verify all again.
   if (furtherVerification) {
@@ -2684,7 +2684,7 @@ async function storeZelAppRunningMessage(message) {
   if (myCache.has(serviceHelper.ensureString(message))) {
     return false;
   }
-  console.log(message);
+  console.log(serviceHelper.ensureString(message));
   myCache.set(serviceHelper.ensureString(message), message);
 
   const validTill = message.broadcastedAt + (65 * 60 * 1000); // 3900 seconds

--- a/ZelBack/src/services/zelcashService.js
+++ b/ZelBack/src/services/zelcashService.js
@@ -20,8 +20,8 @@ let zelcashCallRunning = false;
 
 // default cache
 const LRUoptions = {
-  max: 500, // store 500 values for up to 15 seconds of other zelcash calls
-  maxAge: 1000 * 15, // 15 seconds
+  max: 500, // store 500 values for up to 20 seconds of other zelcash calls
+  maxAge: 1000 * 20, // 20 seconds
 };
 const cache = new LRU(LRUoptions);
 
@@ -37,15 +37,31 @@ async function executeCall(rpc, params) {
   try {
     let data;
     if (zelcashCallRunning) {
-      const randomDelay = Math.floor((Math.random() * 250)) + 50;
+      const randomDelay = Math.floor((Math.random() * 250)) + 60;
       await serviceHelper.delay(randomDelay);
     }
     if (zelcashCallRunning) {
-      const randomDelay = Math.floor((Math.random() * 150)) + 50;
+      const randomDelay = Math.floor((Math.random() * 200)) + 50;
       await serviceHelper.delay(randomDelay);
     }
     if (zelcashCallRunning) {
-      const randomDelay = Math.floor((Math.random() * 50)) + 50;
+      const randomDelay = Math.floor((Math.random() * 150)) + 40;
+      await serviceHelper.delay(randomDelay);
+    }
+    if (zelcashCallRunning) {
+      const randomDelay = Math.floor((Math.random() * 100)) + 30;
+      await serviceHelper.delay(randomDelay);
+    }
+    if (zelcashCallRunning) {
+      const randomDelay = Math.floor((Math.random() * 75)) + 25;
+      await serviceHelper.delay(randomDelay);
+    }
+    if (zelcashCallRunning) {
+      const randomDelay = Math.floor((Math.random() * 50)) + 20;
+      await serviceHelper.delay(randomDelay);
+    }
+    if (zelcashCallRunning) {
+      const randomDelay = Math.floor((Math.random() * 25)) + 10;
       await serviceHelper.delay(randomDelay);
     }
     if (rpc === 'getBlock') {

--- a/ZelBack/src/services/zelfluxCommunication.js
+++ b/ZelBack/src/services/zelfluxCommunication.js
@@ -378,7 +378,7 @@ async function respondWithAppMessage(message, ws) {
       sendMessageToWS(tempMesResponse, ws);
       return;
     }
-    console.log(message);
+    console.log(serviceHelper.ensureString(message));
     const permanentMessage = await zelappsService.checkZelAppMessageExistence(message.data.hash);
     if (permanentMessage) {
       // message exists in permanent storage. Create a message and broadcast it to the fromIP peer

--- a/ZelBack/src/services/zelfluxCommunication.js
+++ b/ZelBack/src/services/zelfluxCommunication.js
@@ -80,10 +80,14 @@ async function myZelNodeIP() {
 
 async function deterministicZelNodeList() {
   try {
+    const request = {
+      params: {},
+      query: {},
+    };
     let zelnodeList = [];
     zelnodeList = myCache.get('zelnodeList');
     if (!zelnodeList) {
-      const zelcashZelNodeList = await zelcashService.viewDeterministicZelNodeList();
+      const zelcashZelNodeList = await zelcashService.viewDeterministicZelNodeList(request);
       if (zelcashZelNodeList.status === 'success') {
         zelnodeList = zelcashZelNodeList.data || [];
         myCache.set('zelnodeList', zelnodeList); // default ttl of 60 sec

--- a/ZelBack/src/services/zelfluxCommunication.js
+++ b/ZelBack/src/services/zelfluxCommunication.js
@@ -26,12 +26,12 @@ let myFluxIP = null;
 let response = serviceHelper.createErrorMessage();
 // default cache
 const LRUoptions = {
-  max: 200, // store 200 values, we shall not have more values at any period
-  maxAge: 1000 * 120, // 120 seconds
+  max: 250, // store 250 values, we shall not have more values at any period
+  maxAge: 1000 * 150, // 150 seconds slightly over average blocktime. Allowing 1 block expired too.
 };
 
 const myCache = new LRU(LRUoptions);
-const myMessageCache = new LRU(200);
+const myMessageCache = new LRU(250);
 
 // basic check for a version of other flux.
 async function isFluxAvailable(ip) {

--- a/ZelFront/src/assets/css/main.css
+++ b/ZelFront/src/assets/css/main.css
@@ -233,7 +233,11 @@ h4 {
   display: inline-block;
 }
 
-.el-menu--collapse .el-submenu .is-opened > .el-submenu__title .el-submenu__icon-arrow {
+.el-menu--collapse
+  .el-submenu
+  .is-opened
+  > .el-submenu__title
+  .el-submenu__icon-arrow {
   -webkit-transform: rotateZ(180deg);
   -ms-transform: rotateZ(180deg);
   transform: rotateZ(180deg);
@@ -351,4 +355,11 @@ h4 {
 
 .width25 {
   width: 25%;
+}
+
+.spaceLeft {
+  margin-top: -20px;
+  display: grid;
+  grid-template-columns: auto 150px;
+  margin-bottom: 10px;
 }

--- a/ZelFront/src/assets/css/main.css
+++ b/ZelFront/src/assets/css/main.css
@@ -348,3 +348,7 @@ h4 {
   margin-bottom: 30px;
   width: 96%;
 }
+
+.width25 {
+  width: 25%;
+}

--- a/ZelFront/src/components/ZelAdmin.vue
+++ b/ZelFront/src/components/ZelAdmin.vue
@@ -71,6 +71,30 @@
     </div>
     <div v-if="zelAdminSection === 'manageflux'">
       <p>
+        Manage your Crux ID. In case of additional node rewards, users can send you assets to the following Crux ID.
+      </p>
+      <br>
+      <el-input
+        class="width25"
+        placeholder="Crux ID"
+        v-model="cruxidInput"
+      >
+      </el-input>
+      <br>
+      <el-popconfirm
+        confirmButtonText='Update'
+        cancelButtonText='No, Thanks'
+        icon="el-icon-info"
+        iconColor="orange"
+        title="Flux will now update your Crux ID."
+        @onConfirm="adjustCruxID()"
+      >
+        <ElButton slot="reference">
+          Update Crux ID
+        </ElButton>
+      </el-popconfirm>
+      <el-divider></el-divider>
+      <p>
         Update your Flux to the latest version. Every Flux has to run the newest version to stay on par with the network.
       </p>
       <el-dialog
@@ -529,6 +553,7 @@ import Vuex, { mapState } from 'vuex';
 import Vue from 'vue';
 import axios from 'axios';
 
+import ZelFluxService from '@/services/ZelFluxService';
 import zelIDService from '@/services/ZelIDService';
 import ZelNodeService from '@/services/ZelNodeService';
 import ZelCashService from '@/services/ZelCashService';
@@ -554,6 +579,7 @@ export default {
       rescanExplorerHeight: 0,
       rescanGlobalAppsHeight: 0,
       removeLastInformation: false,
+      cruxidInput: '',
     };
   },
   computed: {
@@ -587,6 +613,7 @@ export default {
           this.loggedSessions();
           break;
         case 'manageflux':
+          this.getCruxID();
           this.getLatestZelFluxVersion();
           break;
         case 'managezelcash':
@@ -604,6 +631,10 @@ export default {
         default:
           console.log('zelAdmin Section: Unrecognized method'); // should not be seeable if all works correctly
       }
+    },
+    async getCruxID() {
+      const response = await ZelFluxService.getCruxID();
+      this.cruxidInput = response.data.data;
     },
     updateZelFlux() {
       const zelidauth = localStorage.getItem('zelidauth');
@@ -1258,6 +1289,20 @@ export default {
           console.log(e);
           vue.$customMes.error(e.toString());
         });
+    },
+    async adjustCruxID() {
+      const cruxId = this.cruxidInput;
+      const zelidauth = localStorage.getItem('zelidauth');
+      try {
+        const cruxIDResponse = await ZelFluxService.adjustCruxID(zelidauth, cruxId);
+        if (cruxIDResponse.data.status === 'error') {
+          vue.$customMes.error(cruxIDResponse.data.data.message || cruxIDResponse.data.data);
+        } else {
+          vue.$customMes.success(cruxIDResponse.data.data.message || cruxIDResponse.data.data);
+        }
+      } catch (error) {
+        vue.$customMes.error(error.message || error);
+      }
     },
   },
 };

--- a/ZelFront/src/components/ZelApps.vue
+++ b/ZelFront/src/components/ZelApps.vue
@@ -725,7 +725,7 @@
               <p>
                 Registered on Blockheight: {{ callResponse.data.height }}
               </p>
-              <p>
+              <p v-if="callResponse.data.hash.length === 64">
                 Expires on Blockheight: {{ callResponse.data.height + 22000 }}
               </p>
               <p>
@@ -816,7 +816,7 @@
               <p>
                 Registered on Blockheight: {{ callBResponse.data.height }}
               </p>
-              <p>
+              <p v-if="callResponse.data.hash.length === 64">
                 Expires on Blockheight: {{ callBResponse.data.height + 22000 }}
               </p>
               <p>
@@ -1176,7 +1176,7 @@
               <p>
                 Registered on Blockheight: {{ callBResponse.data.height }}
               </p>
-              <p>
+              <p v-if="callResponse.data.hash.length === 64">
                 Expires on Blockheight: {{ callBResponse.data.height + 22000 }}
               </p>
               <p>

--- a/ZelFront/src/components/ZelApps.vue
+++ b/ZelFront/src/components/ZelApps.vue
@@ -1877,6 +1877,9 @@
       >
       </el-input>
     </div>
+    <div v-if="zelAppsSection === 'zelshare'">
+      <ZelShare />
+    </div>
   </div>
 </template>
 
@@ -1887,6 +1890,8 @@ import Vue from 'vue';
 import ZelCashService from '@/services/ZelCashService';
 import ZelAppsService from '@/services/ZelAppsService';
 
+const ZelShare = () => import('@/components/ZelShare.vue');
+
 const store = require('store');
 const qs = require('qs');
 
@@ -1896,6 +1901,9 @@ const vue = new Vue();
 
 export default {
   name: 'ZelApps',
+  components: {
+    ZelShare,
+  },
   data() {
     return {
       timeoptions: {

--- a/ZelFront/src/components/ZelShare.vue
+++ b/ZelFront/src/components/ZelShare.vue
@@ -469,7 +469,7 @@ export default {
           vue.$customMes.error(response.data.data.message || response.data.data);
         } else {
           this.loadFolder(this.currentFolder, true);
-          vue.$$customMes.success(`${name} deleted`);
+          vue.$customMes.success(`${name} deleted`);
         }
       } catch (error) {
         console.log(error.message);

--- a/ZelFront/src/components/ZelShare.vue
+++ b/ZelFront/src/components/ZelShare.vue
@@ -138,6 +138,7 @@
                 v-if="total[scope.row.name] && downloaded[scope.row.name] && total[scope.row.name] !== downloaded[scope.row.name]"
                 content="Cancel Download"
                 placement="top"
+                hide-after="6000"
               >
                 <el-button
                   v-if="total[scope.row.name] && downloaded[scope.row.name] && total[scope.row.name] !== downloaded[scope.row.name]"

--- a/ZelFront/src/components/ZelShare.vue
+++ b/ZelFront/src/components/ZelShare.vue
@@ -7,22 +7,17 @@
       :default-sort="{prop: 'name', order: 'ascending'}"
       :default-sort-method="sortNameFolder"
     >
-      <template slot="empty">
-        <slot
-          name="empty"
-          v-if="$slots.empty"
-        >
-          <p v-if="loadingFolder">
-            Local Specifications loading<i class="el-icon-loading"></i>
-          </p>
-          <p v-else-if="filterFolder">
-            No files found
-          </p>
-          <p v-else>
-            Folder is empty
-          </p>
-        </slot>
-      </template>
+      <div slot="empty">
+        <p v-if="loadingFolder">
+          Loading folder <i class="el-icon-loading"></i>
+        </p>
+        <p v-else-if="filterFolder">
+          No files found
+        </p>
+        <p v-else>
+          Folder is empty
+        </p>
+      </div>
       <el-table-column
         label="Name"
         prop="name"
@@ -490,7 +485,6 @@ export default {
           vue.$customMes.success(`${name} deleted`);
         }
       } catch (error) {
-        console.log(error.message);
         vue.$customMes.error(error.message || error);
       }
     },
@@ -501,14 +495,18 @@ export default {
           folderPath = `${this.currentFolder}/${foldername}`;
         }
         const response = await ZelAppsService.removeFolder(this.zelidHeader.zelidauth, encodeURIComponent(folderPath));
+        console.log(response.data);
         if (response.data.status === 'error') {
-          vue.$customMes.error(response.data.data.message || response.data.data);
+          if (response.data.data.code === 'ENOTEMPTY') {
+            vue.$customMes.error(`Directory ${foldername} is not empty!`);
+          } else {
+            vue.$customMes.error(response.data.data.message || response.data.data);
+          }
         } else {
           this.loadFolder(this.currentFolder, true);
           vue.$customMes.success(`${foldername} deleted`);
         }
       } catch (error) {
-        console.log(error.message);
         vue.$customMes.error(error.message || error);
       }
     },

--- a/ZelFront/src/components/ZelShare.vue
+++ b/ZelFront/src/components/ZelShare.vue
@@ -150,7 +150,7 @@
               </el-tooltip>
             </p>
             <el-button
-              v-if="scope.row.isFile && scope.row.shareHash"
+              v-if="scope.row.isFile && scope.row.shareToken"
               type="success"
               icon="el-icon-share"
               circle
@@ -158,7 +158,7 @@
               @click="unshareFile(scope.row.name)"
             ></el-button>
             <el-button
-              v-if="scope.row.isFile && !scope.row.shareHash"
+              v-if="scope.row.isFile && !scope.row.shareToken"
               type="info"
               icon="el-icon-share"
               circle
@@ -166,13 +166,13 @@
               @click="shareFile(scope.row.name)"
             ></el-button>
             <el-tooltip
-              v-if="scope.row.isFile && scope.row.shareHash"
-              :content="createZelShareLink(scope.row.shareFile, scope.row.shareHash)"
+              v-if="scope.row.isFile && scope.row.shareToken"
+              :content="createZelShareLink(scope.row.shareFile, scope.row.shareToken)"
               placement="top"
               enterable
             >
               <el-button
-                v-if="scope.row.isFile && scope.row.shareHash"
+                v-if="scope.row.isFile && scope.row.shareToken"
                 type="info"
                 icon="el-icon-message"
                 circle
@@ -630,8 +630,8 @@ export default {
       }
       return true;
     },
-    createZelShareLink(name, hash) {
-      return `${this.ipAddress}:16127/zelapps/zelshare/getfile/${name}/${hash}`;
+    createZelShareLink(name, token) {
+      return `${this.ipAddress}:16127/zelapps/zelshare/getfile/${name}/${token}`;
     },
   },
 };

--- a/ZelFront/src/components/ZelShare.vue
+++ b/ZelFront/src/components/ZelShare.vue
@@ -500,7 +500,7 @@ export default {
         if (this.currentFolder !== '') {
           folderPath = `${this.currentFolder}/${foldername}`;
         }
-        const response = await ZelAppsService.removeFile(this.zelidHeader.zelidauth, encodeURIComponent(folderPath));
+        const response = await ZelAppsService.removeFolder(this.zelidHeader.zelidauth, encodeURIComponent(folderPath));
         if (response.data.status === 'error') {
           vue.$customMes.error(response.data.data.message || response.data.data);
         } else {

--- a/ZelFront/src/components/ZelShare.vue
+++ b/ZelFront/src/components/ZelShare.vue
@@ -105,43 +105,47 @@
         width="200px"
       >
         <template slot="header">
-          <el-input
-            v-model="filterFolder"
-            size="mini"
-            placeholder="Type to search"
-          />
+          <p style="text-align: center">
+            <el-input
+              v-model="filterFolder"
+              size="mini"
+              placeholder="Type to search"
+            />
+          </p>
         </template>
         <template slot-scope="scope">
-          <el-button
-            v-if="scope.row.isFile && !downloaded[scope.row.name]"
-            icon="el-icon-download"
-            size="mini"
-            type="info"
-            @click="download(scope.row.name)"
-          >Download</el-button>
-          <p v-if="total[scope.row.name] && downloaded[scope.row.name]">
-            {{ (downloaded[scope.row.name] / 1e6).toFixed(2) + " / " + (total[scope.row.name] / 1e6).toFixed(2) }} MB
-            <br>
-            {{ ((downloaded[scope.row.name] / total[scope.row.name]) * 100).toFixed(2) + "%" }}
-            <i
-              v-if="total[scope.row.name] && downloaded[scope.row.name] && total[scope.row.name] === downloaded[scope.row.name]"
-              class="el-icon-success"
-            ></i>
-            <el-tooltip
-              v-if="total[scope.row.name] && downloaded[scope.row.name] && total[scope.row.name] !== downloaded[scope.row.name]"
-              content="Cancel Download"
-              placement="top"
-            >
-              <el-button
+          <div style="text-align: center">
+            <el-button
+              v-if="scope.row.isFile && !downloaded[scope.row.name]"
+              icon="el-icon-download"
+              size="mini"
+              type="info"
+              @click="download(scope.row.name)"
+            >Download</el-button>
+            <p v-if="total[scope.row.name] && downloaded[scope.row.name]">
+              {{ (downloaded[scope.row.name] / 1e6).toFixed(2) + " / " + (total[scope.row.name] / 1e6).toFixed(2) }} MB
+              <br>
+              {{ ((downloaded[scope.row.name] / total[scope.row.name]) * 100).toFixed(2) + "%" }}
+              <i
+                v-if="total[scope.row.name] && downloaded[scope.row.name] && total[scope.row.name] === downloaded[scope.row.name]"
+                class="el-icon-success"
+              ></i>
+              <el-tooltip
                 v-if="total[scope.row.name] && downloaded[scope.row.name] && total[scope.row.name] !== downloaded[scope.row.name]"
-                type="danger"
-                icon="el-icon-close"
-                circle
-                size="mini"
-                @click="cancelDownload(scope.row.name)"
-              ></el-button>
-            </el-tooltip>
-          </p>
+                content="Cancel Download"
+                placement="top"
+              >
+                <el-button
+                  v-if="total[scope.row.name] && downloaded[scope.row.name] && total[scope.row.name] !== downloaded[scope.row.name]"
+                  type="danger"
+                  icon="el-icon-close"
+                  circle
+                  size="mini"
+                  @click="cancelDownload(scope.row.name)"
+                ></el-button>
+              </el-tooltip>
+            </p>
+          </div>
         </template>
       </el-table-column>
       <el-table-column
@@ -149,23 +153,49 @@
         width="165px"
       >
         <template slot="header">
-          <el-button
-            icon="el-icon-upload"
-            size="mini"
-            type="info"
-            @click="uploadFilesDialog = true"
-          >
-            Upload
-          </el-button>
-          <el-button
-            style="padding: 5px;"
-            icon="el-icon-folder-add"
-            circle
-            size="mini"
-            type="info"
-            @click="createDirectoryDialogVisible = true"
-          >
-          </el-button>
+          <p style="text-align: center">
+            <el-button
+              icon="el-icon-upload"
+              size="mini"
+              type="info"
+              @click="uploadFilesDialog = true"
+            >
+              Upload
+            </el-button>
+            <el-button
+              style="padding: 5px;"
+              icon="el-icon-folder-add"
+              circle
+              size="mini"
+              type="info"
+              @click="createDirectoryDialogVisible = true"
+            >
+            </el-button>
+          </p>
+        </template>
+        <template slot-scope="scope">
+          <p style="text-align: center">
+            <el-popconfirm
+              v-if="scope.row.isFile"
+              confirmButtonText='Delete'
+              cancelButtonText='No, Thanks'
+              icon="el-icon-delete"
+              iconColor="red"
+              title="Permanently delete file?"
+              confirmButtonType="danger"
+              cancelButtonType="info"
+              @onConfirm="deleteFile(scope.row.name)"
+            >
+              <el-button
+                slot="reference"
+                icon="el-icon-delete"
+                size="mini"
+                type="danger"
+              >
+                Delete
+              </el-button>
+            </el-popconfirm>
+          </p>
         </template>
       </el-table-column>
     </el-table>
@@ -429,6 +459,22 @@ export default {
     },
     refreshFolder() {
       this.loadFolder(this.currentFolder, true);
+    },
+    async deleteFile(name) {
+      try {
+        const folder = this.currentFolder;
+        const fileName = folder ? `${folder}/${name}` : name;
+        const response = await ZelAppsService.removeFile(this.zelidHeader.zelidauth, encodeURIComponent(fileName));
+        if (response.data.status === 'error') {
+          vue.$customMes.error(response.data.data.message || response.data.data);
+        } else {
+          this.loadFolder(this.currentFolder, true);
+          vue.$$customMes.success(`${name} deleted`);
+        }
+      } catch (error) {
+        console.log(error.message);
+        vue.$customMes.error(error.message || error);
+      }
     },
   },
 };

--- a/ZelFront/src/components/ZelShare.vue
+++ b/ZelFront/src/components/ZelShare.vue
@@ -195,6 +195,26 @@
                 Delete
               </el-button>
             </el-popconfirm>
+            <el-popconfirm
+              v-if="scope.row.isDirectory"
+              confirmButtonText='Delete'
+              cancelButtonText='No, Thanks'
+              icon="el-icon-delete"
+              iconColor="red"
+              title="Only empty directories can be deleted for security reasons. Delete directory?"
+              confirmButtonType="danger"
+              cancelButtonType="info"
+              @onConfirm="deleteFolder(scope.row.name)"
+            >
+              <el-button
+                slot="reference"
+                icon="el-icon-delete"
+                size="mini"
+                type="danger"
+              >
+                Delete
+              </el-button>
+            </el-popconfirm>
           </p>
         </template>
       </el-table-column>
@@ -372,9 +392,7 @@ export default {
     async createFolder(path) {
       try {
         let folderPath = path;
-        if (this.currentFolder === '') {
-          folderPath = path;
-        } else {
+        if (this.currentFolder !== '') {
           folderPath = `${this.currentFolder}/${path}`;
         }
         const response = await ZelAppsService.createFolder(this.zelidHeader.zelidauth, encodeURIComponent(folderPath));
@@ -430,7 +448,7 @@ export default {
         console.log(error.message);
         if (error.message) {
           if (!error.message.startsWith('Download')) {
-            vue.$customMes.error(error.message || error);
+            vue.$customMes.error(error.message);
           }
         } else {
           vue.$customMes.error(error);
@@ -470,6 +488,24 @@ export default {
         } else {
           this.loadFolder(this.currentFolder, true);
           vue.$customMes.success(`${name} deleted`);
+        }
+      } catch (error) {
+        console.log(error.message);
+        vue.$customMes.error(error.message || error);
+      }
+    },
+    async deleteFolder(foldername) {
+      try {
+        let folderPath = foldername;
+        if (this.currentFolder !== '') {
+          folderPath = `${this.currentFolder}/${foldername}`;
+        }
+        const response = await ZelAppsService.removeFile(this.zelidHeader.zelidauth, encodeURIComponent(folderPath));
+        if (response.data.status === 'error') {
+          vue.$customMes.error(response.data.data.message || response.data.data);
+        } else {
+          this.loadFolder(this.currentFolder, true);
+          vue.$customMes.success(`${foldername} deleted`);
         }
       } catch (error) {
         console.log(error.message);

--- a/ZelFront/src/components/ZelShare.vue
+++ b/ZelFront/src/components/ZelShare.vue
@@ -149,6 +149,36 @@
                 ></el-button>
               </el-tooltip>
             </p>
+            <el-button
+              v-if="scope.row.isFile && scope.row.shareHash"
+              type="success"
+              icon="el-icon-share"
+              circle
+              size="mini"
+              @click="unshareFile(scope.row.name)"
+            ></el-button>
+            <el-button
+              v-if="scope.row.isFile && !scope.row.shareHash"
+              type="info"
+              icon="el-icon-share"
+              circle
+              size="mini"
+              @click="shareFile(scope.row.name)"
+            ></el-button>
+            <el-popover
+              placement="top"
+              title="ZelShare Link"
+              trigger="click"
+              :content="createZelShareLink(scope.row.shareName, scope.row.shareHash)"
+            >
+              <el-button
+                v-if="scope.row.isFile && scope.row.shareHash"
+                type="info"
+                icon="el-icon-message"
+                circle
+                size="mini"
+              ></el-button>
+            </el-popover>
           </div>
         </template>
       </el-table-column>
@@ -535,6 +565,36 @@ export default {
         vue.$customMes.error(error.message || error);
       }
     },
+    async shareFile(name) {
+      try {
+        const folder = this.currentFolder;
+        const fileName = folder ? `${folder}/${name}` : name;
+        const response = await ZelAppsService.shareFile(this.zelidHeader.zelidauth, encodeURIComponent(fileName));
+        if (response.data.status === 'error') {
+          vue.$customMes.error(response.data.data.message || response.data.data);
+        } else {
+          this.loadFolder(this.currentFolder, true);
+          vue.$customMes.success(`${name} shared`);
+        }
+      } catch (error) {
+        vue.$customMes.error(error.message || error);
+      }
+    },
+    async unshareFile(name) {
+      try {
+        const folder = this.currentFolder;
+        const fileName = folder ? `${folder}/${name}` : name;
+        const response = await ZelAppsService.unshareFile(this.zelidHeader.zelidauth, encodeURIComponent(fileName));
+        if (response.data.status === 'error') {
+          vue.$customMes.error(response.data.data.message || response.data.data);
+        } else {
+          this.loadFolder(this.currentFolder, true);
+          vue.$customMes.success(`${name} unshared`);
+        }
+      } catch (error) {
+        vue.$customMes.error(error.message || error);
+      }
+    },
     async deleteFolder(foldername) {
       try {
         let folderPath = foldername;
@@ -569,6 +629,9 @@ export default {
         return false;
       }
       return true;
+    },
+    createZelShareLink(name, hash) {
+      return `${this.ipAddress}:16127/zelapps/zelshare/getfile/${name}/${hash}`;
     },
   },
 };

--- a/ZelFront/src/components/ZelShare.vue
+++ b/ZelFront/src/components/ZelShare.vue
@@ -166,6 +166,7 @@
               @click="shareFile(scope.row.name)"
             ></el-button>
             <el-tooltip
+              v-if="scope.row.isFile && scope.row.shareHash"
               :content="createZelShareLink(scope.row.shareFile, scope.row.shareHash)"
               placement="top"
               enterable

--- a/ZelFront/src/components/ZelShare.vue
+++ b/ZelFront/src/components/ZelShare.vue
@@ -165,11 +165,10 @@
               size="mini"
               @click="shareFile(scope.row.name)"
             ></el-button>
-            <el-popover
+            <el-tooltip
+              :content="createZelShareLink(scope.row.shareFile, scope.row.shareHash)"
               placement="top"
-              title="ZelShare Link"
-              trigger="click"
-              :content="createZelShareLink(scope.row.shareName, scope.row.shareHash)"
+              enterable
             >
               <el-button
                 v-if="scope.row.isFile && scope.row.shareHash"
@@ -178,7 +177,7 @@
                 circle
                 size="mini"
               ></el-button>
-            </el-popover>
+            </el-tooltip>
           </div>
         </template>
       </el-table-column>

--- a/ZelFront/src/components/ZelShare.vue
+++ b/ZelFront/src/components/ZelShare.vue
@@ -364,7 +364,6 @@ export default {
         const response = await ZelAppsService.storageStats(this.zelidHeader.zelidauth);
         console.log(response);
         if (response.data.status === 'success') {
-          this.folderView = response.data.data;
           this.storage.total = response.data.data.total;
           this.storage.used = response.data.data.used;
           this.storage.available = response.data.data.available;

--- a/ZelFront/src/components/ZelShare.vue
+++ b/ZelFront/src/components/ZelShare.vue
@@ -1,5 +1,14 @@
 <template>
   <div>
+    <p class="spaceLeft">
+      <el-progress
+        :text-inside="true"
+        :percentage="percentage"
+        :color="customColors"
+        :stroke-width="20"
+      ></el-progress>
+      {{ storage.used.toFixed(2) + ' / ' + storage.total.toFixed(2) }} GB
+    </p>
     <el-table
       ref="shareTable"
       :data="folderContentFilter"
@@ -307,12 +316,23 @@ export default {
         total: 2,
         available: 2,
       },
+      customColors: [
+        { color: '#6f7ad3', percentage: 20 },
+        { color: '#1989fa', percentage: 40 },
+        { color: '#5cb87a', percentage: 60 },
+        { color: '#e6a23c', percentage: 80 },
+        { color: '#f56c6c', percentage: 100 },
+      ],
     };
   },
   computed: {
     ...mapState([
       'userconfig',
     ]),
+    percentage() {
+      const perc = (this.storage.used / this.storage.total) * 100;
+      return Number(perc.toFixed(2));
+    },
     zelidHeader() {
       const zelidauth = localStorage.getItem('zelidauth');
       const headers = {

--- a/ZelFront/src/components/shared/Footer.vue
+++ b/ZelFront/src/components/shared/Footer.vue
@@ -10,8 +10,8 @@
       >
         <el-option
           key="Default"
-          :label="`http://${externalip}:${port}`"
-          :value="`http://${externalip}:${port}`"
+          :label="`http://${userconfig.externalip}:${port}`"
+          :value="`http://${userconfig.externalip}:${port}`"
         >
         </el-option>
       </el-select>
@@ -39,7 +39,6 @@ import ZelNodeService from '@/services/ZelNodeService';
 const store = require('store');
 
 const config = require('../../../../ZelBack/config/default');
-const userconfig = require('../../../../config/userconfig');
 
 Vue.use(Vuex);
 const vue = new Vue();
@@ -49,17 +48,17 @@ export default {
   data() {
     return {
       backendURL: '',
-      externalip: userconfig.initial.ipaddress,
       port: config.server.apiport,
     };
   },
   computed: {
     ...mapState([
+      'userconfig',
       'zelfluxVersion',
     ]),
   },
   mounted() {
-    this.backendURL = store.get('backendURL') || `http://${this.externalip}:${this.port}`;
+    this.backendURL = store.get('backendURL') || `http://${this.userconfig.externalip}:${this.port}`;
     const self = this;
     ZelNodeService.getZelFluxVersion()
       .then((response) => {

--- a/ZelFront/src/components/shared/Header.vue
+++ b/ZelFront/src/components/shared/Header.vue
@@ -228,6 +228,12 @@
         <el-menu-item index="4-1">Local ZelApps</el-menu-item>
         <el-menu-item index="4-2">Global ZelApps</el-menu-item>
         <el-menu-item index="4-3">Register ZelApp</el-menu-item>
+        <el-menu-item
+          v-if="privilage === 'admin'"
+          index="4-4"
+        >
+          ZelShare Storage
+        </el-menu-item>
       </el-submenu>
       <el-submenu
         v-if="privilage === 'user' || privilage === 'admin' || privilage === 'zelteam'"
@@ -454,6 +460,9 @@ export default {
           break;
         case '4-3':
           this.$store.commit('setZelAppsSection', 'registerzelapp');
+          break;
+        case '4-4':
+          this.$store.commit('setZelAppsSection', 'zelshare');
           break;
         case '10-1':
           this.$store.commit('setZelAdminSection', 'loggedsessions');

--- a/ZelFront/src/pages/MainPage.vue
+++ b/ZelFront/src/pages/MainPage.vue
@@ -88,7 +88,6 @@
         Loading...
       </h4>
     </div>
-     <ZelShare />
     <div class="footer">
       <Footer />
     </div>
@@ -111,7 +110,6 @@ const ZelNode = () => import('@/components/ZelNode.vue');
 const ZelAdmin = () => import('@/components/ZelAdmin.vue');
 const ZelApps = () => import('@/components/ZelApps.vue');
 const Explorer = () => import('@/components/Explorer.vue');
-const ZelShare = () => import('@/components/ZelShare.vue');
 
 const qs = require('qs');
 
@@ -121,7 +119,7 @@ const vue = new Vue();
 export default {
   name: 'MainPage',
   components: {
-    Header, Footer, Login, ZelCash, ZelBench, ZelNode, ZelAdmin, ZelApps, Explorer, ZelShare,
+    Header, Footer, Login, ZelCash, ZelBench, ZelNode, ZelAdmin, ZelApps, Explorer,
   },
   data() {
     return {

--- a/ZelFront/src/pages/MainPage.vue
+++ b/ZelFront/src/pages/MainPage.vue
@@ -88,6 +88,7 @@
         Loading...
       </h4>
     </div>
+     <ZelShare />
     <div class="footer">
       <Footer />
     </div>
@@ -110,6 +111,7 @@ const ZelNode = () => import('@/components/ZelNode.vue');
 const ZelAdmin = () => import('@/components/ZelAdmin.vue');
 const ZelApps = () => import('@/components/ZelApps.vue');
 const Explorer = () => import('@/components/Explorer.vue');
+const ZelShare = () => import('@/components/ZelShare.vue');
 
 const qs = require('qs');
 
@@ -119,7 +121,7 @@ const vue = new Vue();
 export default {
   name: 'MainPage',
   components: {
-    Header, Footer, Login, ZelCash, ZelBench, ZelNode, ZelAdmin, ZelApps, Explorer,
+    Header, Footer, Login, ZelCash, ZelBench, ZelNode, ZelAdmin, ZelApps, Explorer, ZelShare,
   },
   data() {
     return {

--- a/ZelFront/src/services/ZelAppsService.js
+++ b/ZelFront/src/services/ZelAppsService.js
@@ -228,6 +228,13 @@ export default {
       },
     });
   },
+  storageStats(zelidauthHeader) {
+    return Api().get('/zelapps/zelshare/stats', {
+      headers: {
+        zelidauth: zelidauthHeader,
+      },
+    });
+  },
   justAPI() {
     return Api();
   },

--- a/ZelFront/src/services/ZelAppsService.js
+++ b/ZelFront/src/services/ZelAppsService.js
@@ -208,6 +208,14 @@ export default {
       },
     });
   },
+  removeFile(zelidauthHeader, file) {
+    console.log(file);
+    return Api().get(`/zelapps/zelshare/removefile/${file}`, {
+      headers: {
+        zelidauth: zelidauthHeader,
+      },
+    });
+  },
   justAPI() {
     return Api();
   },

--- a/ZelFront/src/services/ZelAppsService.js
+++ b/ZelFront/src/services/ZelAppsService.js
@@ -214,6 +214,20 @@ export default {
       },
     });
   },
+  shareFile(zelidauthHeader, file) {
+    return Api().get(`/zelapps/zelshare/sharefile/${file}`, {
+      headers: {
+        zelidauth: zelidauthHeader,
+      },
+    });
+  },
+  unshareFile(zelidauthHeader, file) {
+    return Api().get(`/zelapps/zelshare/unsharefile/${file}`, {
+      headers: {
+        zelidauth: zelidauthHeader,
+      },
+    });
+  },
   removeFolder(zelidauthHeader, folder) {
     return Api().get(`/zelapps/zelshare/removefolder/${folder}`, {
       headers: {

--- a/ZelFront/src/services/ZelAppsService.js
+++ b/ZelFront/src/services/ZelAppsService.js
@@ -201,7 +201,6 @@ export default {
     });
   },
   getFile(zelidauthHeader, file) {
-    console.log(file);
     return Api().get(`/zelapps/zelshare/getfile/${file}`, {
       headers: {
         zelidauth: zelidauthHeader,
@@ -209,8 +208,14 @@ export default {
     });
   },
   removeFile(zelidauthHeader, file) {
-    console.log(file);
     return Api().get(`/zelapps/zelshare/removefile/${file}`, {
+      headers: {
+        zelidauth: zelidauthHeader,
+      },
+    });
+  },
+  removeFolder(zelidauthHeader, folder) {
+    return Api().get(`/zelapps/zelshare/removefolder/${folder}`, {
       headers: {
         zelidauth: zelidauthHeader,
       },

--- a/ZelFront/src/services/ZelAppsService.js
+++ b/ZelFront/src/services/ZelAppsService.js
@@ -221,6 +221,13 @@ export default {
       },
     });
   },
+  fileExists(zelidauthHeader, file) {
+    return Api().get(`/zelapps/zelshare/fileexists/${file}`, {
+      headers: {
+        zelidauth: zelidauthHeader,
+      },
+    });
+  },
   justAPI() {
     return Api();
   },

--- a/ZelFront/src/services/ZelAppsService.js
+++ b/ZelFront/src/services/ZelAppsService.js
@@ -186,6 +186,28 @@ export default {
   getAppPirce(specifications) {
     return Api().post('/zelapps/calculateprice', JSON.stringify(specifications));
   },
+  getFolder(zelidauthHeader, folder) {
+    return Api().get(`/zelapps/zelshare/getfolder/${folder}`, {
+      headers: {
+        zelidauth: zelidauthHeader,
+      },
+    });
+  },
+  createFolder(zelidauthHeader, folder) {
+    return Api().get(`/zelapps/zelshare/createfolder/${folder}`, {
+      headers: {
+        zelidauth: zelidauthHeader,
+      },
+    });
+  },
+  getFile(zelidauthHeader, file) {
+    console.log(file);
+    return Api().get(`/zelapps/zelshare/getfile/${file}`, {
+      headers: {
+        zelidauth: zelidauthHeader,
+      },
+    });
+  },
   justAPI() {
     return Api();
   },

--- a/ZelFront/src/services/ZelFluxService.js
+++ b/ZelFront/src/services/ZelFluxService.js
@@ -46,6 +46,16 @@ export default {
       },
     });
   },
+  adjustCruxID(zelidauthHeader, cruxid) {
+    return Api().get(`/zelid/adjustcruxid/${cruxid}`, {
+      headers: {
+        zelidauth: zelidauthHeader,
+      },
+    });
+  },
+  getCruxID() {
+    return Api().get('/zelflux/cruxid');
+  },
   // DEBUG
   tailFluxDebug(zelidauthHeader) {
     return Api().get('/zelnode/tailzelfluxerrorlog', {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "element-ui": "^2.13.0",
     "express": "^4.17.1",
     "express-ws": "^4.0.0",
-    "formidable": "^1.2.2",
+    "formidable": "^2.0.0-canary.20200504.1",
     "fullnode": "file:lib/fullnode",
     "inquirer": "^7.0.0",
     "mongodb": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "ciconfig": "cp sampleUserConfig.js config/userconfig.js && mkdir ~/.zelcash && cp sampleZelCashConfig.conf ~/.zelcash/zelcash.conf"
   },
   "dependencies": {
+    "apicache": "1.5.2",
     "axios": "^0.19.0",
     "bitcoin": "^3.0.1",
     "bitcoinjs-lib": "^5.1.6",
@@ -63,8 +64,10 @@
     "formidable": "^2.0.0-canary.20200504.1",
     "fullnode": "file:lib/fullnode",
     "inquirer": "^7.0.0",
+    "lru-cache": "^6.0.0",
     "mongodb": "^3.4.0",
     "morgan": "^1.9.1",
+    "node-cache": "^5.1.2",
     "node-cmd": "^3.0.0",
     "node-df": "^0.1.4",
     "nodemon": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zelflux",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Flux - Node Daemon. The entrace to the Flux network.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "lru-cache": "^6.0.0",
     "mongodb": "^3.4.0",
     "morgan": "^1.9.1",
-    "node-cache": "^5.1.2",
     "node-cmd": "^3.0.0",
     "node-df": "^0.1.4",
     "nodemon": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "element-ui": "^2.13.0",
     "express": "^4.17.1",
     "express-ws": "^4.0.0",
+    "formidable": "^1.2.2",
     "fullnode": "file:lib/fullnode",
     "inquirer": "^7.0.0",
     "mongodb": "^3.4.0",


### PR DESCRIPTION
Introducing ZelShare
- Personal ZelNode owner storage.
- Store and Share your files with comfortable ZelFlux UI directly on your ZelNode
- Total storage size limited to 2GB + whatever is an excess storage above ZelNode specification. (example: Running a Super Node with total of 200GB of data shall grant you 200 - 150 + 2 = 52GB of storage for ZelShare)
- File upload is limited to 5GB
- Ability to upload multiple files at once, download a file, delete file, empty folder, create folder, share file
- More features will come soon


Kadena Specificaitons V2
- Kadena application will now update to newer version 
- New installation will use boostrapped database to speed up syncing


Following API adjusted - available only with ZelNode owner authentication header
```
GET /zelapps/zelshare/getfile/:file?/:token?
GET /zelapps/zelshare/getfolder/:folder?
GET /zelapps/zelshare/createfolder/:folder?
GET /zelapps/zelshare/removefile/:file?
GET /zelapps/zelshare/removefolder/:folder?
GET /zelapps/zelshare/fileexists/:file?
GET /zelapps/zelshare/stats'
GET /zelapps/zelshare/sharefile/:file?
GET /zelapps/zelshare/unsharefile/:file?
GET /zelapps/zelshare/sharedfiles
POST /zelapps/zelshare/uploadfile/:folder?
```

Other changes
- Introducing Caches - Flux now uses multiple LRU caches in itself especially with communications to ZelCash daemon. Speeding up many processes, reducing general load on the node and dramatically reducing load on ZelCash daemon
- Api Caches - Portion of Flux API is now behind cache granting faster responses and reducing Flux resources.
- With caches in place, browsing recent data of explorer is now faster
- It is now possible to adjust cruxID from Admin UI
- Faster application redeployment
- Other minor mprovements and fixes
