### PR TITLE
v1.4.1

### DIFF
--- a/ZelBack/src/services/serviceManager.js
+++ b/ZelBack/src/services/serviceManager.js
@@ -55,10 +55,10 @@ async function startFluxFunctions() {
     }, 4 * 60 * 1000);
     log.info('Flux Block Processing Service started');
     setTimeout(() => {
-      // after 10 minutes of running ok.
+      // after 16 minutes of running ok.
       log.info('Starting to spawn applications');
       zelappsService.trySpawningGlobalApplication();
-    }, 10 * 60 * 1000);
+    }, 16 * 60 * 1000);
   } catch (e) {
     log.error(e);
     setTimeout(() => {

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -1339,6 +1339,7 @@ async function removeZelAppLocally(zelapp, res, force = false, endResponse = tru
     const dbopen = serviceHelper.databaseConnection();
 
     const zelappsDatabase = dbopen.db(config.database.zelappslocal.database);
+    const database = dbopen.db(config.database.zelappsglobal.database);
 
     const zelappsQuery = { name: zelapp };
     const zelappsProjection = {};
@@ -1348,7 +1349,7 @@ async function removeZelAppLocally(zelapp, res, force = false, endResponse = tru
         throw new Error('ZelApp not found');
       }
       // get it from global Specifications
-      zelAppSpecifications = await serviceHelper.findOneInDatabase(zelappsDatabase, globalZelAppsInformation, zelappsQuery, zelappsProjection);
+      zelAppSpecifications = await serviceHelper.findOneInDatabase(database, globalZelAppsInformation, zelappsQuery, zelappsProjection);
       // get it from locally available Specifications
       // eslint-disable-next-line no-use-before-define
       const allZelApps = await availableZelApps();
@@ -1357,7 +1358,7 @@ async function removeZelAppLocally(zelapp, res, force = false, endResponse = tru
       if (!zelAppSpecifications) {
         const query = {};
         const projection = { projection: { _id: 0 } };
-        const messages = await serviceHelper.findInDatabase(zelappsDatabase, globalZelAppsMessages, query, projection);
+        const messages = await serviceHelper.findInDatabase(database, globalZelAppsMessages, query, projection);
         const appMessages = messages.filter((message) => message.zelAppSpecifications.name === zelapp);
         let currentSpecifications = {};
         appMessages.forEach((message) => {

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -1360,13 +1360,13 @@ async function removeZelAppLocally(zelapp, res, force = false, endResponse = tru
         const projection = { projection: { _id: 0 } };
         const messages = await serviceHelper.findInDatabase(database, globalZelAppsMessages, query, projection);
         const appMessages = messages.filter((message) => message.zelAppSpecifications.name === zelapp);
-        let currentSpecifications = {};
+        let currentSpecifications;
         appMessages.forEach((message) => {
-          if (message.height > currentSpecifications.height) {
+          if (!currentSpecifications || message.height > currentSpecifications.height) {
             currentSpecifications = message;
           }
         });
-        if (currentSpecifications.height) {
+        if (currentSpecifications && currentSpecifications.height) {
           zelAppSpecifications = currentSpecifications.zelAppSpecifications;
         }
       }

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -1355,7 +1355,9 @@ async function removeZelAppLocally(zelapp, res, force = false, endResponse = tru
       zelAppSpecifications = allZelApps.find((app) => app.name === zelapp);
       // get it from permanent messages
       if (!zelAppSpecifications) {
-        const messages = await serviceHelper.findOneInDatabase(zelappsDatabase, globalZelAppsMessages, zelappsQuery, zelappsProjection);
+        const query = {};
+        const projection = { projection: { _id: 0 } };
+        const messages = await serviceHelper.findInDatabase(zelappsDatabase, globalZelAppsMessages, query, projection);
         const appMessages = messages.filter((message) => message.zelAppSpecifications.name === zelapp);
         let currentSpecifications = {};
         appMessages.forEach((message) => {

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -42,6 +42,8 @@ const LRUoptions = {
 };
 const myCache = new LRU(LRUoptions);
 
+let removalInProgress = false;
+
 function getZelAppIdentifier(zelappName) {
   // this id is used for volumes, docker names so we know it reall belongs to zelflux
   if (zelappName.startsWith('zel')) {
@@ -1325,6 +1327,7 @@ async function removeZelAppLocally(zelapp, res, force = false, endResponse = tru
     // remove zelapp from local machine.
     // find in database, stop zelapp, remove container, close port delete data associated on system, remove from database
     // we want to remove the image as well (repotag) what if other container uses the same image -> then it shall result in an error so ok anyway
+    removalInProgress = true;
     if (!zelapp) {
       throw new Error('No ZelApp specified');
     }
@@ -1339,10 +1342,30 @@ async function removeZelAppLocally(zelapp, res, force = false, endResponse = tru
 
     const zelappsQuery = { name: zelapp };
     const zelappsProjection = {};
-    const zelAppSpecifications = await serviceHelper.findOneInDatabase(zelappsDatabase, localZelAppsInformation, zelappsQuery, zelappsProjection);
+    let zelAppSpecifications = await serviceHelper.findOneInDatabase(zelappsDatabase, localZelAppsInformation, zelappsQuery, zelappsProjection);
     if (!zelAppSpecifications) {
       if (!force) {
         throw new Error('ZelApp not found');
+      }
+      // get it from global Specifications
+      zelAppSpecifications = await serviceHelper.findOneInDatabase(zelappsDatabase, globalZelAppsInformation, zelappsQuery, zelappsProjection);
+      // get it from locally available Specifications
+      // eslint-disable-next-line no-use-before-define
+      const allZelApps = await availableZelApps();
+      zelAppSpecifications = allZelApps.find((app) => app.name === zelapp);
+      // get it from permanent messages
+      if (!zelAppSpecifications) {
+        const messages = await serviceHelper.findOneInDatabase(zelappsDatabase, globalZelAppsMessages, zelappsQuery, zelappsProjection);
+        const appMessages = messages.filter((message) => message.zelAppSpecifications.name === zelapp);
+        let currentSpecifications = {};
+        appMessages.forEach((message) => {
+          if (message.height > currentSpecifications.height) {
+            currentSpecifications = message;
+          }
+        });
+        if (currentSpecifications.height) {
+          zelAppSpecifications = currentSpecifications.zelAppSpecifications;
+        }
       }
     }
 
@@ -1508,7 +1531,9 @@ async function removeZelAppLocally(zelapp, res, force = false, endResponse = tru
         res.end();
       }
     }
+    removalInProgress = false;
   } catch (error) {
+    removalInProgress = false;
     log.error(error);
     const errorResponse = serviceHelper.createErrorMessage(
       error.message || error,
@@ -4231,8 +4256,13 @@ async function checkAndNotifyPeersOfRunningApps() {
           log.warn(`${stoppedApp} is stopped but shall be running. Starting...`);
           // it is a stopped global zelapp. Try to run it.
           const zelappId = getZelAppIdentifier(stoppedApp);
-          // eslint-disable-next-line no-await-in-loop
-          await zelAppDockerStart(zelappId);
+          // check if some removal is in progress as if it is dont start it!
+          if (!removalInProgress) {
+            // eslint-disable-next-line no-await-in-loop
+            await zelAppDockerStart(zelappId);
+          } else {
+            log.warn(`Not starting ${stoppedApp} as of application removal in progress`);
+          }
         }
       } catch (err) {
         log.error(err);

--- a/ZelBack/src/services/zelappsService.js
+++ b/ZelBack/src/services/zelappsService.js
@@ -1350,24 +1350,26 @@ async function removeZelAppLocally(zelapp, res, force = false, endResponse = tru
       }
       // get it from global Specifications
       zelAppSpecifications = await serviceHelper.findOneInDatabase(database, globalZelAppsInformation, zelappsQuery, zelappsProjection);
-      // get it from locally available Specifications
-      // eslint-disable-next-line no-use-before-define
-      const allZelApps = await availableZelApps();
-      zelAppSpecifications = allZelApps.find((app) => app.name === zelapp);
-      // get it from permanent messages
       if (!zelAppSpecifications) {
-        const query = {};
-        const projection = { projection: { _id: 0 } };
-        const messages = await serviceHelper.findInDatabase(database, globalZelAppsMessages, query, projection);
-        const appMessages = messages.filter((message) => message.zelAppSpecifications.name === zelapp);
-        let currentSpecifications;
-        appMessages.forEach((message) => {
-          if (!currentSpecifications || message.height > currentSpecifications.height) {
-            currentSpecifications = message;
+        // get it from locally available Specifications
+        // eslint-disable-next-line no-use-before-define
+        const allZelApps = await availableZelApps();
+        zelAppSpecifications = allZelApps.find((app) => app.name === zelapp);
+        // get it from permanent messages
+        if (!zelAppSpecifications) {
+          const query = {};
+          const projection = { projection: { _id: 0 } };
+          const messages = await serviceHelper.findInDatabase(database, globalZelAppsMessages, query, projection);
+          const appMessages = messages.filter((message) => message.zelAppSpecifications.name === zelapp);
+          let currentSpecifications;
+          appMessages.forEach((message) => {
+            if (!currentSpecifications || message.height > currentSpecifications.height) {
+              currentSpecifications = message;
+            }
+          });
+          if (currentSpecifications && currentSpecifications.height) {
+            zelAppSpecifications = currentSpecifications.zelAppSpecifications;
           }
-        });
-        if (currentSpecifications && currentSpecifications.height) {
-          zelAppSpecifications = currentSpecifications.zelAppSpecifications;
         }
       }
     }

--- a/ZelBack/src/services/zelfluxCommunication.js
+++ b/ZelBack/src/services/zelfluxCommunication.js
@@ -222,7 +222,7 @@ async function sendToAllPeers(data, wsList) {
         await serviceHelper.delay(100);
         client.send(data);
       } catch (e) {
-        log.error(e);
+        console.log(e);
         removals.push(client);
         try {
           const ip = client._socket.remoteAddress;
@@ -266,7 +266,7 @@ async function sendToAllIncomingConnections(data, wsList) {
         await serviceHelper.delay(100);
         client.send(data);
       } catch (e) {
-        log.error(e);
+        console.log(e);
         removals.push(client);
         try {
           const ip = client._socket.remoteAddress;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zelflux",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Flux - Node Daemon. The entrace to the Flux network.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
App Removal Fixes
Background: When Flux decides that application shall be removed, this removal could have been interrupted by another Flux process deciding that application shall be running. Tracing like this:
1) Removal process stops ZelApp
2) Check Running Apps starts the ZelApp which was supposed to be removed
3) Removal process fails to remove ZelApp properly leaving some data of ZelApp on the node.
- Correct Removal of application with force. Using force parameter will now further check global specifications, locally available specifications and permanent messages ensuring that some specifications are found.
- Wait with starting a stopped application if removal is in progress

Other Tweaks
- Increase timeout from when Flux begins application installation from 10 mins to 16 mins
-> this allows more zelapprunning messages to be present to better determine if an application shall be spawned
- Remove logging of failing to broadcast a message to peer